### PR TITLE
v2dl3 script name

### DIFF
--- a/scripts/ANALYSIS.anasum_parallel_from_runlist_v2dl3.sh
+++ b/scripts/ANALYSIS.anasum_parallel_from_runlist_v2dl3.sh
@@ -171,7 +171,7 @@ mkdir -p "$ODIR"
 
 #########################################
 # make script for v2dl3
-V2DL3SCRIPT="$ODIR/$CUTS_v2dl3_for_runlist_from_ED485-anasum.sh"
+V2DL3SCRIPT="$ODIR/${CUTS}_v2dl3_for_runlist_from_ED485-anasum.sh"
 echo "#!/bin/sh " >> $V2DL3SCRIPT
 echo "" >> $V2DL3SCRIPT
 


### PR DESCRIPTION
variable `CUTS` in the v2dl3 script name without { } does not take the remaining string upto ED485 and writes only **-anasum.sh** file in the output directory.