### PR TITLE
v490 - alpha.12 - BDT gamma/hadron separation training and testing

### DIFF
--- a/scripts/ANALYSIS.anasum_parallel_from_runlist.sh
+++ b/scripts/ANALYSIS.anasum_parallel_from_runlist.sh
@@ -25,7 +25,9 @@ required parameters:
                             (for BDT preparation: NTel2ModeratePre, NTel2SoftPre, NTel2Pre, NTel3Pre)
     
     <background model>      background model
-                            (RE = reflected region, RB = ring background, IGNOREACCEPTANCE = RE without ACCEPTANCE)
+                            (RE = reflected region, RB = ring background, 
+                            IGNOREACCEPTANCE = RE without ACCEPTANCE,
+                            IGNOREIRF = RE without ACCEPTANCE/EFFAREA)
     
 optional parameters:
 
@@ -146,9 +148,9 @@ elif [[ $CUT == *ExtendedSource-* ]]; then
 fi
 
 RADACC="radialAcceptance-${IRFVERSION}-${AUXVERSION}-SX-Cut-${CUTRADACC}-${ANATYPE}-VX-TX.root"
-# START TEMPORARY (TESTS, comment)
-# EFFAREA="IGNOREEFFECTIVEAREA"
-# END TEMPORARY
+if [[ "$BACKGND" == *IGNOREIRF* ]]; then
+  EFFAREA="IGNOREEFFECTIVEAREA"
+fi
 
 echo "$CUTFILE"
 echo "$EFFAREA"
@@ -166,7 +168,7 @@ if [[ "$BACKGND" == *RB* ]]; then
         echo "Specify an acceptance (external=0, runwise=1) or use RE."
         exit 1
     fi
-elif [[ "$BACKGND" == *IGNOREACCEPTANCE* ]]; then
+elif [[ "$BACKGND" == *IGNOREACCEPTANCE* ]] || [[ "$BACKGND" == *IGNOREIRF* ]]; then
     BM="RE"
     BMPARAMS="0.1 2 6"
     RADACC="IGNOREACCEPTANCE"

--- a/scripts/ANALYSIS.anasum_parallel_from_runlist.sh
+++ b/scripts/ANALYSIS.anasum_parallel_from_runlist.sh
@@ -89,7 +89,10 @@ SIMTYPE_DEFAULT_V6UV="CARE_UV_2212"
 
 ANATYPE="AP"
 if [[ ! -z  $VERITAS_ANALYSIS_TYPE ]]; then
-    ANATYPE="$VERITAS_ANALYSIS_TYPE"
+   ANATYPE="${VERITAS_ANALYSIS_TYPE:0:2}"
+   if [[ ${VERITAS_ANALYSIS_TYPE} == *"DISP"* ]]; then
+      DISPBDT="1"
+   fi
 fi
 
 # cut definitions (note: VX to be replaced later in script)

--- a/scripts/ANALYSIS.mscw_energy.sh
+++ b/scripts/ANALYSIS.mscw_energy.sh
@@ -66,6 +66,14 @@ RLIST=$1
 [[ "$6" ]] && FORCEDATMO=$6
 [[ "$7" ]] && INPUTLOGDIR=$7 || INPUTLOGDIR=${INPUTDIR}
 DISPBDT="0"
+ANATYPE="AP"
+if [[ ! -z  $VERITAS_ANALYSIS_TYPE ]]; then
+   ANATYPE="${VERITAS_ANALYSIS_TYPE:0:2}"
+   echo "AAA $ANATYPE"
+   if [[ ${VERITAS_ANALYSIS_TYPE} == *"DISP"* ]]; then
+      DISPBDT="1"
+   fi
+fi
 
 SIMTYPE_DEFAULT_V4="GRISU"
 SIMTYPE_DEFAULT_V5="GRISU"
@@ -145,11 +153,6 @@ do
         SIMTYPE_RUN="$SIMTYPE"
     fi
 
-    ANATYPE="AP"
-    if [[ ! -z  $VERITAS_ANALYSIS_TYPE ]]; then
-       ANATYPE="$VERITAS_ANALYSIS_TYPE"
-    fi 
- 
     TABFILE=table-${IRFVERSION}-auxv01-${SIMTYPE_RUN}-ATM${ATMO}-${EPOCH}-${ANATYPE}.root
     echo "TABLEFILE: $TABFILE"
     # Check that table file exists

--- a/scripts/ANALYSIS.mscw_energy.sh
+++ b/scripts/ANALYSIS.mscw_energy.sh
@@ -69,7 +69,6 @@ DISPBDT="0"
 ANATYPE="AP"
 if [[ ! -z  $VERITAS_ANALYSIS_TYPE ]]; then
    ANATYPE="${VERITAS_ANALYSIS_TYPE:0:2}"
-   echo "AAA $ANATYPE"
    if [[ ${VERITAS_ANALYSIS_TYPE} == *"DISP"* ]]; then
       DISPBDT="1"
    fi

--- a/scripts/IRF.generalproduction.sh
+++ b/scripts/IRF.generalproduction.sh
@@ -20,7 +20,7 @@ required parameters:
                             (e.g. EVNDISP, MAKETABLES, COMBINETABLES,
                              (ANALYSETABLES, EFFECTIVEAREAS,)
                              ANATABLESEFFAREAS, COMBINEEFFECTIVEAREAS,
-                             MVAEVNDISP, TRAINMVANGRES, EVNDISPCOMPRESS )
+                             MVAEVNDISP, TRAINTMVA, TRAINMVANGRES, EVNDISPCOMPRESS )
 
 --------------------------------------------------------------------------------
 "

--- a/scripts/IRF.generalproduction.sh
+++ b/scripts/IRF.generalproduction.sh
@@ -20,7 +20,8 @@ required parameters:
                             (e.g. EVNDISP, MAKETABLES, COMBINETABLES,
                              (ANALYSETABLES, EFFECTIVEAREAS,)
                              ANATABLESEFFAREAS, COMBINEEFFECTIVEAREAS,
-                             MVAEVNDISP, TRAINTMVA, TRAINMVANGRES, EVNDISPCOMPRESS )
+                             MVAEVNDISP, TRAINTMVA, OPTIMIZETMVA, 
+                             TRAINMVANGRES, EVNDISPCOMPRESS )
 
 --------------------------------------------------------------------------------
 "

--- a/scripts/IRF.optimizeTMVAforGammaHadronSeparation.sh
+++ b/scripts/IRF.optimizeTMVAforGammaHadronSeparation.sh
@@ -119,15 +119,15 @@ if [[ $SUBC == *qsub* ]]; then
  fi
  echo "JOBID:  $JOBID"
 elif [[ $SUBC == *condor* ]]; then
-$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh $FSCRIPT.sh $h_vmem $tmpdir_size
-# condor_submit $FSCRIPT.sh.condor
+   $(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh $FSCRIPT.sh $h_vmem $tmpdir_size
+#   condor_submit $FSCRIPT.sh.condor
 elif [[ $SUBC == *sbatch* ]]; then
     $SUBC $FSCRIPT.sh
 elif [[ $SUBC == *parallel* ]]; then
- echo "$FSCRIPT.sh &> $FSCRIPT.log" >> $LOGDIR/runscripts.dat
- cat $LOGDIR/runscripts.dat | $SUBC
+    echo "$FSCRIPT.sh &> $FSCRIPT.log" >> $LOGDIR/runscripts.dat
+    cat $LOGDIR/runscripts.dat | $SUBC
 elif [[ "$SUBC" == *simple* ]] ; then
- "$FSCRIPT.sh" | tee "$FSCRIPT.log"
+    "$FSCRIPT.sh" | tee "$FSCRIPT.log"
 fi
 
 exit

--- a/scripts/IRF.optimizeTMVAforGammaHadronSeparation.sh
+++ b/scripts/IRF.optimizeTMVAforGammaHadronSeparation.sh
@@ -91,7 +91,7 @@ NZEW=$((${#ZEBINARRAY[@]}-$count1)) #get number of bins
 # Job submission script
 SUBSCRIPT=$(dirname "$0")"/helper_scripts/IRF.optimizeTMVAforGammaHadronSeparation_sub"
 
-FSCRIPT="$LOGDIR/IRF.optimizeTMVAforGammaHadronSeparation_sub"
+FSCRIPT="$LOGDIR/IRF.optimizeTMVAforGammaHadronSeparation_sub_${EPOCH}_ATM${ATM}"
 sed -e "s|EFFFILE|$EFFFILE|"  \
     -e "s|ODIR|$PREDIR|" \
     -e "s|EEPOCH|${EPOCH}|" \
@@ -120,7 +120,7 @@ if [[ $SUBC == *qsub* ]]; then
  echo "JOBID:  $JOBID"
 elif [[ $SUBC == *condor* ]]; then
    $(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh $FSCRIPT.sh $h_vmem $tmpdir_size
-#   condor_submit $FSCRIPT.sh.condor
+   condor_submit $FSCRIPT.sh.condor
 elif [[ $SUBC == *sbatch* ]]; then
     $SUBC $FSCRIPT.sh
 elif [[ $SUBC == *parallel* ]]; then

--- a/scripts/IRF.optimizeTMVAforGammaHadronSeparation.sh
+++ b/scripts/IRF.optimizeTMVAforGammaHadronSeparation.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# script to optimize BDT cuts
+#
+#
+
+h_cpu=11:59:59; h_vmem=4000M; tmpdir_size=1G
+
+if [[ $# -lt 5 ]]; then
+# begin help message
+echo "
+Optimize BDT cuts for TMVA with signal rates from MC and background rates from data.
+
+IRF.optimizeTMVAforGammaHadronSeparation.sh <preselection results directory> <cut type> <sim type> <epoch> <atmosphere>
+
+required parameters:
+
+    <preselection results directory>     directory with preselection results
+
+    <cut type>               preselection cut type (e.g., NTel2-Moderate)
+    
+    <sim type>                      original VBF file simulation type (e.g. GRISU, CARE_June2020)
+
+    <epoch>                         array epoch e.g. V4, V5, V6, V6_2012_2013a
+
+    <atmosphere>                    atmosphere model(s) (61 = winter, 62 = summer)
+
+--------------------------------------------------------------------------------
+"
+#end help message
+exit
+fi
+echo " "
+# Run init script
+bash $(dirname "$0")"/helper_scripts/UTILITY.script_init.sh"
+[[ $? != "0" ]] && exit 1
+
+# Parse command line arguments
+PREDIR=$1
+CUTTYPE=$2
+SIMTYPE=$3
+EPOCH=$4
+ATM=$5
+# evndisplay version
+IRFVERSION=`$EVNDISPSYS/bin/trainTMVAforGammaHadronSeparation --version | tr -d .| sed -e 's/[a-Z]*$//'`
+
+DISPBDT=""
+ANATYPE="AP"
+if [[ ! -z $VERITAS_ANALYSIS_TYPE ]]; then
+    ANATYPE="${VERITAS_ANALYSIS_TYPE:0:2}"
+    if [[ ${VERITAS_ANALYSIS_TYPE} == *"DISP"* ]]; then
+        DISPBDT="_DISP"
+    fi 
+fi
+
+# Check that list of background files exists
+if [[ ! -d "${PREDIR}/${CUTTYPE}" ]]; then
+    echo "Error, directory with background files ${PREDIR}/${CUTTYPE} not found, exiting..."
+    exit 1
+fi
+
+#####################################
+# directory for run scripts
+DATE=`date +"%y%m%d"`
+LOGDIR="$PREDIR/${CUTTYPE}/$DATE/"
+echo -e "Log files will be written to:\n $LOGDIR"
+mkdir -p $LOGDIR
+
+# EffAreaFile
+if [[ $CUTTYPE == *"Moderate"* ]]; then
+    EFFFILE=effArea-v490-auxv01-${SIMTYPE}-Cut-NTel2-PointSource-Moderate-TMVA-Preselection-${VERITAS_ANALYSIS_TYPE/_/-}-${EPOCH}-ATM${ATM}-T1234.root
+fi
+
+if [[ ! -e $VERITAS_EVNDISP_AUX_DIR/EffectiveAreas/${EFFFILE} ]]; then
+    echo "Error - effective area file not found ${EFFFILE}"
+fi
+
+RUNPAR="$VERITAS_EVNDISP_AUX_DIR/ParameterFiles/TMVA.BDT.runparameter"
+#####################################
+# energy bins
+ENBINS=$( cat "$RUNPAR" | grep "^* ENERGYBINS 1" | sed -e 's/* ENERGYBINS 1//' | sed -e 's/ /\n/g')
+declare -a EBINARRAY=( $ENBINS ) #convert to array
+count1=1
+NENE=$((${#EBINARRAY[@]}-$count1)) #get number of bins
+
+#####################################
+# zenith angle bins
+ZEBINS=$( cat "$RUNPAR" | grep "^* ZENBINS " | sed -e 's/* ZENBINS//' | sed -e 's/ /\n/g')
+declare -a ZEBINARRAY=( $ZEBINS ) #convert to array
+NZEW=$((${#ZEBINARRAY[@]}-$count1)) #get number of bins
+
+# Job submission script
+SUBSCRIPT=$(dirname "$0")"/helper_scripts/IRF.optimizeTMVAforGammaHadronSeparation_sub"
+
+FSCRIPT="$LOGDIR/IRF.optimizeTMVAforGammaHadronSeparation_sub"
+sed -e "s|EFFFILE|$EFFFILE|"  \
+    -e "s|ODIR|$PREDIR|" \
+    -e "s|EEPOCH|${EPOCH}|" \
+    -e "s|AATM|${ATM}|" \
+    -e "s|EEBINS|${NENE}|" \
+    -e "s|ZZBINS|${NZEW}|" \
+    -e "s|CUTTYPE|${CUTTYPE}|" $SUBSCRIPT.sh > $FSCRIPT.sh
+
+chmod u+x $FSCRIPT.sh
+echo $FSCRIPT.sh
+
+# run locally or on cluster
+SUBC=`$(dirname "$0")/helper_scripts/UTILITY.readSubmissionCommand.sh`
+SUBC=`eval "echo \"$SUBC\""`
+if [[ $SUBC == *"ERROR"* ]]; then
+    echo $SUBC
+    exit
+fi
+if [[ $SUBC == *qsub* ]]; then
+ JOBID=`$SUBC $FSCRIPT.sh`
+ # account for -terse changing the job number format
+ if [[ $SUBC != *-terse* ]] ; then
+    echo "without -terse!"      # need to match VVVVVVVV  8539483  and 3843483.1-4:2
+    JOBID=$( echo "$JOBID" | grep -oP "Your job [0-9.-:]+" | awk '{ print $3 }' )
+ fi
+ echo "JOBID:  $JOBID"
+elif [[ $SUBC == *condor* ]]; then
+$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh $FSCRIPT.sh $h_vmem $tmpdir_size
+# condor_submit $FSCRIPT.sh.condor
+elif [[ $SUBC == *sbatch* ]]; then
+    $SUBC $FSCRIPT.sh
+elif [[ $SUBC == *parallel* ]]; then
+ echo "$FSCRIPT.sh &> $FSCRIPT.log" >> $LOGDIR/runscripts.dat
+ cat $LOGDIR/runscripts.dat | $SUBC
+elif [[ "$SUBC" == *simple* ]] ; then
+ "$FSCRIPT.sh" | tee "$FSCRIPT.log"
+fi
+
+exit

--- a/scripts/IRF.optimizeTMVAforGammaHadronSeparation.sh
+++ b/scripts/IRF.optimizeTMVAforGammaHadronSeparation.sh
@@ -77,10 +77,30 @@ fi
 RUNPAR="$VERITAS_EVNDISP_AUX_DIR/ParameterFiles/TMVA.BDT.runparameter"
 #####################################
 # energy bins
-ENBINS=$( cat "$RUNPAR" | grep "^* ENERGYBINS 1" | sed -e 's/* ENERGYBINS 1//' | sed -e 's/ /\n/g')
-declare -a EBINARRAY=( $ENBINS ) #convert to array
-count1=1
-NENE=$((${#EBINARRAY[@]}-$count1)) #get number of bins
+if grep -q "^* ENERGYBINS" "$RUNPAR"; then
+    ENBINS=$( cat "$RUNPAR" | grep "^* ENERGYBINS 1" | sed -e 's/* ENERGYBINS 1//' | sed -e 's/ /\n/g')
+    declare -a EBINARRAY=( $ENBINS ) #convert to array
+    count1=1
+    NENE=$((${#EBINARRAY[@]}-$count1)) #get number of bins
+    for (( i=0; i < $NENE; i++ ))
+    do
+        EBINMIN[$i]=${EBINARRAY[$i]}
+        EBINMAX[$i]=${EBINARRAY[$i+1]}
+    done
+else
+    ENBINS=$( cat "$RUNPAR" | grep "^* ENERGYBINEDGES" | sed -e 's/* ENERGYBINEDGES//' | sed -e 's/ /\n/g')
+    declare -a EBINARRAY=( $ENBINS ) #convert to array
+    count1=1
+    NENE=$((${#EBINARRAY[@]}-$count1)) #get number of bins
+    z="0"
+    for (( i=0; i < $NENE; i+=2 ))
+    do
+        EBINMIN[$z]=${EBINARRAY[$i]}
+        EBINMAX[$z]=${EBINARRAY[$i+1]}
+        let "z = ${z} + 1"
+    done
+    NENE=$((${#EBINMAX[@]}))
+fi
 
 #####################################
 # zenith angle bins

--- a/scripts/IRF.production.sh
+++ b/scripts/IRF.production.sh
@@ -146,8 +146,8 @@ elif [[ "${SIMTYPE}" = "CARE_June2020" ]]; then
     WOBBLE_OFFSETS=$(ls ${SIMDIR}/*/* | awk -F "_" '{print $7}' |  awk -F "wob" '{print $1}' | sort -u)
     ######################################
     # TEST
-    # NSB_LEVELS=( 160 200 250 )
-    #  ZENITH_ANGLES=( 20 )
+    NSB_LEVELS=( 160 )
+    ZENITH_ANGLES=( 20 )
     WOBBLE_OFFSETS=( 0.5 )
     ######################################
     # TEMPORARY
@@ -221,18 +221,18 @@ fi
 #          ANASUM.GammaHadron-Cut-NTel2-PointSource-Moderate.dat"
 # CUTLIST="ANASUM.GammaHadron-Cut-NTel2-PointSource-Moderate.dat"
 # CUTLIST="ANASUM.GammaHadron-Cut-NTel2-PointSource-SuperSoft.dat"
-CUTLIST="ANASUM.GammaHadron-Cut-NTel2-PointSource-Moderate-TMVA-Preselection.dat"
-#CUTLIST="ANASUM.GammaHadron-Cut-NTel2-PointSource-Moderate-TMVA-BDT.dat"
+# CUTLIST="ANASUM.GammaHadron-Cut-NTel2-PointSource-Moderate-TMVA-Preselection.dat"
+CUTLIST="ANASUM.GammaHadron-Cut-NTel2-PointSource-Moderate-TMVA-BDT.dat"
 # CUTLIST="ANASUM.GammaHadron-Cut-NTel3-PointSource-SuperHard-TMVA-BDT.dat"
 CUTLIST=`echo $CUTLIST |tr '\r' ' '`
 CUTLIST=${CUTLIST//$'\n'/}
 
 # Cut types are used for BDT training and optimisation
-CUTTYPES="NTel2-Moderate
-          NTel2-Soft
-          NTel3-Hard"
+CUTTYPES="NTel2-PointSource-Moderate
+          NTel2-PointSource-Soft
+          NTel3-PointSource-Hard"
 # TMP
-CUTTYPES="NTel2-Moderate"
+CUTTYPES="NTel2-PointSource-Moderate"
 CUTTYPES=`echo $CUTTYPES |tr '\r' ' '`
 CUTTYPES=${CUTTYPES//$'\n'/}
 
@@ -310,7 +310,7 @@ for VX in $EPOCH; do
                              echo "OPTIMIZE TMVA $C"
                              ./IRF.optimizeTMVAforGammaHadronSeparation.sh \
                                  "$BDTDIR/BackgroundRates" \
-                                 "${C}" \
+                                 "${C/PointSource-/}" \
                                  ${SIMTYPE} ${VX} "${ATM}"
                          fi
                     done

--- a/scripts/IRF.production.sh
+++ b/scripts/IRF.production.sh
@@ -228,9 +228,11 @@ CUTLIST=`echo $CUTLIST |tr '\r' ' '`
 CUTLIST=${CUTLIST//$'\n'/}
 
 # Cut types are used for BDT training and optimisation
-CUTTYPES="NTel2-PointSource-Moderate
-          NTel2-PointSource-Soft
-          NTel3-PointSource-Hard"
+CUTTYPES="NTel2-Moderate
+          NTel2-Soft
+          NTel3-Hard"
+# TMP
+CUTTYPES="NTel2-Moderate"
 CUTTYPES=`echo $CUTTYPES |tr '\r' ' '`
 CUTTYPES=${CUTTYPES//$'\n'/}
 
@@ -303,10 +305,11 @@ for VX in $EPOCH; do
                                          "${TRAINDIR}" \
                                          "$MVADIR"/BDT.runparameter \
                                          "${MVADIR}" BDT ${SIMTYPE} ${VX} "${ATM}"
+                         # Cut optimization
                          elif [[ $IRFTYPE == "OPTIMIZETMVA" ]]; then
                              echo "OPTIMIZE TMVA $C"
                              ./IRF.optimizeTMVAforGammaHadronSeparation.sh \
-                                 "$MVADIR" \
+                                 "$BDTDIR/BackgroundRates" \
                                  "${C}" \
                                  ${SIMTYPE} ${VX} "${ATM}"
                          fi

--- a/scripts/IRF.production.sh
+++ b/scripts/IRF.production.sh
@@ -145,9 +145,9 @@ elif [[ "${SIMTYPE}" = "CARE_June2020" ]]; then
     WOBBLE_OFFSETS=$(ls ${SIMDIR}/*/* | awk -F "_" '{print $7}' |  awk -F "wob" '{print $1}' | sort -u)
     ######################################
     # TEST
-    NSB_LEVELS=( 160 200 250 )
+    # NSB_LEVELS=( 160 200 250 )
     #  ZENITH_ANGLES=( 20 )
-    WOBBLE_OFFSETS=( 0.25 0.75 1.0 1.5 )
+    WOBBLE_OFFSETS=( 0.5 )
     ######################################
     # TEMPORARY
     # TEST PRODUCTION
@@ -270,13 +270,16 @@ for VX in $EPOCH; do
                     for C in "NTel2-PointSource-Moderate" "NTel2-PointSource-Soft" "NTel3-PointSource-Hard"
                     do
                         echo "Training $C cuts for ${VX} ATM${ATM}"
-                        BDTDIR="${VERITAS_USER_DATA_DIR}/analysis/Results/${EDVERSION}/${VERITAS_ANALYSIS_TYPE}/BDTtraining/"
+                        BDTDIR="${VERITAS_USER_DATA_DIR}/analysis/Results/${EDVERSION}/${ANATYPE}/BDTtraining/"
                         MVADIR="${BDTDIR}/${VX}_ATM${ATM}/${C/PointSource-/}/"
-                        mkdir -p -v "${MVADIR}"
                         # list of background files
-                        # (TODO: select atmosphere / epoch file)
                         # (TODO: nominal/redHV/UVfilter)
                         TRAINDIR="${BDTDIR}/mscw/"
+                        if [[ $DISPBDT == "1" ]]; then
+                            TRAINDIR="${BDTDIR}/mscw_DISP/"
+                            MVADIR="${BDTDIR}/DISP/${VX}_ATM${ATM}/${C/PointSource-/}/"
+                        fi 
+                        mkdir -p -v "${MVADIR}"
                         # retrieve size cut
                         CUTFIL="$VERITAS_EVNDISP_AUX_DIR"/GammaHadronCutFiles/ANASUM.GammaHadron-Cut-${C}-TMVA-Preselection.dat
                         echo "CUTFILE: $CUTFIL"

--- a/scripts/IRF.production.sh
+++ b/scripts/IRF.production.sh
@@ -146,8 +146,8 @@ elif [[ "${SIMTYPE}" = "CARE_June2020" ]]; then
     WOBBLE_OFFSETS=$(ls ${SIMDIR}/*/* | awk -F "_" '{print $7}' |  awk -F "wob" '{print $1}' | sort -u)
     ######################################
     # TEST
-    NSB_LEVELS=( 160 )
-    ZENITH_ANGLES=( 20 )
+    # NSB_LEVELS=( 160 )
+    # ZENITH_ANGLES=( 20 )
     WOBBLE_OFFSETS=( 0.5 )
     ######################################
     # TEMPORARY
@@ -221,8 +221,8 @@ fi
 #          ANASUM.GammaHadron-Cut-NTel2-PointSource-Moderate.dat"
 # CUTLIST="ANASUM.GammaHadron-Cut-NTel2-PointSource-Moderate.dat"
 # CUTLIST="ANASUM.GammaHadron-Cut-NTel2-PointSource-SuperSoft.dat"
-# CUTLIST="ANASUM.GammaHadron-Cut-NTel2-PointSource-Moderate-TMVA-Preselection.dat"
-CUTLIST="ANASUM.GammaHadron-Cut-NTel2-PointSource-Moderate-TMVA-BDT.dat"
+CUTLIST="ANASUM.GammaHadron-Cut-NTel2-PointSource-Moderate-TMVA-Preselection.dat"
+# CUTLIST="ANASUM.GammaHadron-Cut-NTel2-PointSource-Moderate-TMVA-BDT.dat"
 # CUTLIST="ANASUM.GammaHadron-Cut-NTel3-PointSource-SuperHard-TMVA-BDT.dat"
 CUTLIST=`echo $CUTLIST |tr '\r' ' '`
 CUTLIST=${CUTLIST//$'\n'/}

--- a/scripts/IRF.selectRunsForBDTTraining.sh
+++ b/scripts/IRF.selectRunsForBDTTraining.sh
@@ -26,6 +26,9 @@ MEPOCH="V6"
 OBSMODE="observing"
 # Multiplicity
 MULT="1234"
+# Skip runs shorter than this time (s)
+# (require a 10 min run)
+MINOBSTIME=600
 # Sources to avoid
 BRIGHTSOURCES=( Crab Mrk421 )
 
@@ -36,14 +39,19 @@ ZEBINS=$( cat "$RUNPAR" | grep "^* ZENBINS " | sed -e 's/* ZENBINS//' | sed -e '
 echo "Zenith angle definition: $ZEBINS"
 declare -a ZEBINARRAY=( $ZEBINS ) #convert to array
 NZEW=$((${#ZEBINARRAY[@]}-1)) #get number of bins
-for (( j=0; j < $NZEW; j++ ))
-do
-    mkdir -p ${TARGETDIR}/Ze_${j}
-done
 
 FLIST=$(find ${1} -name "*[0-9].mscw.log"  | sed 's/\.log$//')
 
 mkdir -p ${2}
+
+linkFile()
+{
+    mkdir -p $(dirname "$1")
+    if [[ ! -e "$1" ]]; then
+        ln -s "$2" "$1"
+    fi
+}
+
 
 for F in ${FLIST}
 do
@@ -57,22 +65,31 @@ do
             break;
         fi
     done
-    echo "Zenith bin: ${ZEBIN}"
+    echo "   Zenith bin: ${ZEBIN}"
     RUNINFO=$($EVNDISPSYS/bin/printRunParameter ${F}.root -runinfo)
 
     TMPMEPOCH=$(echo $RUNINFO | awk '{print $2}')
     if [[ ${TMPMEPOCH} != ${MEPOCH} ]]; then
         continue
     fi
+    MINOREPOCH=$(echo $RUNINFO | awk '{print $1}')
     TMPOBSMODE=$(echo $RUNINFO | awk '{print $4}')
     if [[ ${TMPOBSMODE} != ${OBSMODE} ]]; then
+        echo "   SKIPPING OBSMODE: ${TMPOBSMODE} ${OBSMODE}"
         continue
     fi
     TMPMULT=$(echo $RUNINFO | awk '{print $5}')
     if [[ ${TMPMULT} != ${MULT} ]]; then
+        echo "   SKIPPING MULT ${TMPMULT} ${MULT}"
         continue
     fi
-    TMPTARGET=$(echo $RUNINFO | cut -d\  -f6- )
+    TMPOBSTIME=$(echo $RUNINFO | awk '{print $6}')
+    if (( $TMPOBSTIME <  $MINOBSTIME )); then
+        echo "   SKIPPING OBSTIME: $TMPOBSTIME $MINOBSTIME" 
+        continue
+    fi
+    TMPTARGET=$(echo $RUNINFO | cut -d\  -f7- )
+    echo "TARGET $TMPTARGET"
     BRK="FALSE"
     for (( l=0; l < ${#BRIGHTSOURCES[@]}; l++ ))
     do
@@ -82,16 +99,15 @@ do
         fi
     done
     if [[ $BRK == "TRUE" ]]; then
-        echo "   skipping $TMPTARGET"
+        echo "   SKIPPING $TMPTARGET"
         continue
     fi
-    echo "   found $TMPTARGET $TMPOBSMODE $TMPMEPOCH $TMPMULT $RUNZENITH (ZE bin ${ZEBIN})"
+    echo "   found $TMPTARGET $TMPOBSMODE $TMPMEPOCH $MINOREPOCH $TMPMULT $TMPOBSTIME $RUNZENITH (ZE bin ${ZEBIN})"
     BNAME=$(basename ${F}.root)
-    if [[ ! -e ${TARGETDIR}/Ze_${ZEBIN}/${BNAME} ]]; then
-        ln -s ${F}.root ${TARGETDIR}/Ze_${ZEBIN}/${BNAME}
-    fi
-    if [[ ! -e ${TARGETDIR}/${BNAME} ]]; then
-        ln -s ${F}.root ${TARGETDIR}/${BNAME}
-    fi
-done
 
+    ## linking
+    linkFile ${TARGETDIR}/${BNAME} ${F}.root
+    linkFile ${TARGETDIR}/Ze_${ZEBIN}/${BNAME} ${F}.root
+    linkFile ${TARGETDIR}/${MINOREPOCH}/${BNAME} ${F}.root
+    linkFile ${TARGETDIR}/${MINOREPOCH}/Ze_${ZEBIN}/${BNAME} ${F}.root
+done

--- a/scripts/IRF.selectRunsForBDTTraining.sh
+++ b/scripts/IRF.selectRunsForBDTTraining.sh
@@ -1,4 +1,4 @@
-# select runs for BDT training
+# select mscw files for BDT training
 # 
 # selection is based on 
 # - epoch
@@ -10,7 +10,7 @@
 #
 
 if [ $# -ne 3 ]; then
-     echo "./IRF.selectRunsForBDTTraining.sh <source evndisp directory> <target evndisp directory> <TMVA run parameter file>"
+     echo "./IRF.selectRunsForBDTTraining.sh <source mscw directory> <target mscw directory> <TMVA run parameter file>"
      echo 
      echo "files are sorted in zenith angle bins defined in TMVA run parameter file"
      echo "this script has several hardwired parameters"

--- a/scripts/IRF.trainTMVAforGammaHadronSeparation.sh
+++ b/scripts/IRF.trainTMVAforGammaHadronSeparation.sh
@@ -98,10 +98,30 @@ mkdir -p $ODIR
 
 #####################################
 # energy bins
-ENBINS=$( cat "$RUNPAR" | grep "^* ENERGYBINS 1" | sed -e 's/* ENERGYBINS 1//' | sed -e 's/ /\n/g')
-declare -a EBINARRAY=( $ENBINS ) #convert to array
-count1=1
-NENE=$((${#EBINARRAY[@]}-$count1)) #get number of bins
+if grep -q "^* ENERGYBINS" "$RUNPAR"; then
+    ENBINS=$( cat "$RUNPAR" | grep "^* ENERGYBINS" | sed -e 's/* ENERGYBINS//' | sed -e 's/ /\n/g')
+    declare -a EBINARRAY=( $ENBINS ) #convert to array
+    count1=1
+    NENE=$((${#EBINARRAY[@]}-$count1)) #get number of bins
+    for (( i=0; i < $NENE; i++ ))
+    do
+        EBINMIN[$i]=${EBINARRAY[$i]}
+        EBINMAX[$i]=${EBINARRAY[$i+1]}
+    done
+else
+    ENBINS=$( cat "$RUNPAR" | grep "^* ENERGYBINEDGES" | sed -e 's/* ENERGYBINEDGES//' | sed -e 's/ /\n/g')
+    declare -a EBINARRAY=( $ENBINS ) #convert to array
+    count1=1
+    NENE=$((${#EBINARRAY[@]}-$count1)) #get number of bins
+    z="0"
+    for (( i=0; i < $NENE; i+=2 ))
+    do
+        EBINMIN[$z]=${EBINARRAY[$i]}
+        EBINMAX[$z]=${EBINARRAY[$i+1]}
+        let "z = ${z} + 1"
+    done
+    NENE=$((${#EBINMAX[@]}))
+fi
 
 #####################################
 # zenith angle bins
@@ -129,7 +149,7 @@ for (( i=0; i < $NENE; i++ ))
 do
    echo "==========================================================================="
    echo " "
-   echo "Energy Bin: $(($i+$count1)) of $NENE: ${EBINARRAY[$i]} to ${EBINARRAY[$i+1]} (in log TeV)"
+   echo "Energy Bin: $(($i+$count1)) of $NENE: ${EBINMIN[$i]} to ${EBINMAX[$i]} (in log TeV)"
 ##############################################
 # loop over all zenith angle bins
    for (( j=0; j < $NZEW; j++ ))
@@ -145,9 +165,9 @@ do
       echo "TMVA Runparameter file: $RFIL.runparameter"
       rm -f $RFIL
       
-      echo "* ENERGYBINS 1 ${EBINARRAY[$i]} ${EBINARRAY[$i+1]}" > $RFIL.runparameter
+      echo "* ENERGYBINS ${EBINMIN[$i]} ${EBINMAX[$i]}" > $RFIL.runparameter
       echo "* ZENBINS  ${ZEBINARRAY[$j]} ${ZEBINARRAY[$j+1]}" >> $RFIL.runparameter
-      grep "*" $RUNPAR | grep -v ENERGYBINS | grep -v ZENBINS | grep -v OUTPUTFILE | grep -v SIGNALFILE | grep -v BACKGROUNDFILE | grep -v MCXYOFF >> $RFIL.runparameter
+      grep "*" $RUNPAR | grep -v ENERGYBINS | grep -v ENERGYBINEDGES | grep -v ZENBINS | grep -v OUTPUTFILE | grep -v SIGNALFILE | grep -v BACKGROUNDFILE | grep -v MCXYOFF >> $RFIL.runparameter
     
       nTrainSignal=200000
       nTrainBackground=200000

--- a/scripts/IRF.trainTMVAforGammaHadronSeparation.sh
+++ b/scripts/IRF.trainTMVAforGammaHadronSeparation.sh
@@ -65,8 +65,13 @@ PARTICLE_TYPE="gamma"
 # evndisplay version
 IRFVERSION=`$EVNDISPSYS/bin/trainTMVAforGammaHadronSeparation --version | tr -d .| sed -e 's/[a-Z]*$//'`
 
-if [[ -z $VERITAS_ANALYSIS_TYPE ]]; then
-    VERITAS_ANALYSIS_TYPE="AP"
+DISPBDT=""
+ANATYPE="AP"
+if [[ ! -z $VERITAS_ANALYSIS_TYPE ]]; then
+    ANATYPE="${VERITAS_ANALYSIS_TYPE:0:2}"
+    if [[ ${VERITAS_ANALYSIS_TYPE} == *"DISP"* ]]; then
+        DISPBDT="_DISP"
+    fi 
 fi
 
 # Check that list of background files exists
@@ -154,7 +159,7 @@ do
       echo "#######################################################################################" >> $RFIL.runparameter
       # signal and background files (depending on on-axis or cone data set)
       for ATMX in $ATM; do
-          SDIR="$VERITAS_IRFPRODUCTION_DIR/$IRFVERSION/$VERITAS_ANALYSIS_TYPE/$SIMTYPE/${EPOCH}_ATM${ATMX}_${PARTICLE_TYPE}/MSCW_RECID${RECID}"
+          SDIR="$VERITAS_IRFPRODUCTION_DIR/$IRFVERSION/$ANATYPE/$SIMTYPE/${EPOCH}_ATM${ATMX}_${PARTICLE_TYPE}/MSCW_RECID${RECID}${DISPBDT}"
           echo "Signal input directory: $SDIR"
           if [[ ! -d $SDIR ]]; then
               echo -e "Error, could not locate directory of simulation files (input). Locations searched:\n $SDIR"

--- a/scripts/helper_scripts/IRF.effective_area_parallel_sub.sh
+++ b/scripts/helper_scripts/IRF.effective_area_parallel_sub.sh
@@ -78,14 +78,15 @@ for CUTSFILE in $CUTSLIST; do
     rm -f $OSUBDIR/$OFILE.root 
     $EVNDISPSYS/bin/makeEffectiveArea $DDIR/$EAPARAMS.dat $DDIR/$EAPARAMS.root &> $OSUBDIR/$EAPARAMS.log
 
-    cp -f $DDIR/$EAPARAMS.root $OSUBDIR/$EAPARAMS.root
     chmod g+w $OSUBDIR/$EAPARAMS.root
     if [[ -f $EVNDISPSYS/bin/logFile ]]; then
+        echo "Filling log file into root file"
         $EVNDISPSYS/bin/logFile effAreaLog $DDIR/$EAPARAMS.root $OSUBDIR/$EAPARAMS.log
         rm -f $OSUBDIR/$EAPARAMS.log
     else
         chmod g+w $OSUBDIR/$EAPARAMS.log
     fi
+    cp -f $DDIR/$EAPARAMS.root $OSUBDIR/$EAPARAMS.root
 
 done
 

--- a/scripts/helper_scripts/IRF.evndisp_MC_sub.sh
+++ b/scripts/helper_scripts/IRF.evndisp_MC_sub.sh
@@ -254,6 +254,7 @@ compare_log_file()
     $EVNDISPSYS/bin/logFile $1 $DDIR/$ONAME.root > ${DDIR}/${1}.log
     if cmp -s "${2}" "${DDIR}/${1}.log"; then
         echo "FILES ${1} ${2} are the same, removing"
+        rm -f "${2}"
     else
         touch $ODIR/$ONAME.${1}.errorlog
         echo "Error, ${1} ${2} differ" >> $ODIR/$ONAME.${1}.errorlog

--- a/scripts/helper_scripts/IRF.optimizeTMVAforGammaHadronSeparation_sub.sh
+++ b/scripts/helper_scripts/IRF.optimizeTMVAforGammaHadronSeparation_sub.sh
@@ -27,20 +27,33 @@ ls -1 ${PREDIR}/${CUT}/*.anasum.root > ${TEMPDIR}/anasum.list
 # effective area - fill path
 EFFAREA="$VERITAS_EVNDISP_AUX_DIR/EffectiveAreas/${EFFAREA}"
 
+# epoch / ATM
+EPAT="${EPOCH}_ATM${ATM}"
+
+# output directory
+WDIR="${PREDIR}/Optimize-${CUT}/"
+mkdir -p ${WDIR}
+
+# rates files
+RATEFILE="${WDIR}/rates_${EPAT}"
+
+rm -f ${RATEFILE}.log
+
 # calculate rates from Crab Nebula and from background rates
 rm -f ${MVADIR}/rates.log
 "$EVNDISPSYS"/bin/calculateCrabRateFromMC \
     ${EFFAREA} \
-    ${PREDIR}/${CUT}/rates_${EPOCH}_ATM${ATM}.root \
+    ${RATEFILE}.root \
     ${ETHRESH} \
     ${VERITAS_EVNDISP_AUX_DIR}/ParameterFiles/TMVA.BDT.runparameter \
-    ${TEMPDIR}/anasum.list  > "${PREDIR}/${CUT}/rates_${EPOCH}_ATM${ATM}.log"
+    ${TEMPDIR}/anasum.list \
+    > ${RATEFILE}.log
 
 # optimize cuts
 echo "optimize cuts..."
-MVADIR="$VERITAS_EVNDISP_AUX_DIR/GammaHadron_BDTs/${EPOCH}_ATM${ATM}/${CUT}/"
+MVADIR="$VERITAS_EVNDISP_AUX_DIR/GammaHadron_BDTs/${EPAT}/${CUT}/"
 cd ${PREDIR}/${CUT}
-rm -f ${PREDIR}/${CUT}/${CUT}.optimised.dat
-root -l -q -b "$EVNDISPSYS/macros/VTS/optimizeBDTcuts.C(\"rates_${EPOCH}_ATM${ATM}.root\", \"$MVADIR\", 0, ${ENBINS}, 0, ${ZEBINS})" > ${PREDIR}/${CUT}/${CUT}_${EPOCH}_ATM${ATM}.optimised.dat
+rm -f ${WDIR}/${EPAT}.optimised.dat
+root -l -q -b "$EVNDISPSYS/macros/VTS/optimizeBDTcuts.C(\"${RATEFILE}.root\", \"$MVADIR\", \"${EPAT}\", 0, ${ENBINS}, 0, ${ZEBINS})"  > ${WDIR}/${EPAT}.optimised.dat
 
 exit

--- a/scripts/helper_scripts/IRF.optimizeTMVAforGammaHadronSeparation_sub.sh
+++ b/scripts/helper_scripts/IRF.optimizeTMVAforGammaHadronSeparation_sub.sh
@@ -41,7 +41,6 @@ echo "optimize cuts..."
 MVADIR="$VERITAS_EVNDISP_AUX_DIR/GammaHadron_BDTs/${EPOCH}_ATM${ATM}/${CUT}/"
 cd ${PREDIR}/${CUT}
 rm -f ${PREDIR}/${CUT}/${CUT}.optimised.dat
-cd $EVNDISPSYS/macros/VTS/
-root -l -q -b "optimizeBDTcuts.C(\"rates_${EPOCH}_ATM${ATM}.root\", \"$MVADIR\", 0, ${ENBINS}, 0, ${ZEBINS})" > ${PREDIR}/${CUT}/${CUT}_${EPOCH}_ATM${ATM}.optimised.dat
+root -l -q -b "$EVNDISPSYS/macros/VTS/optimizeBDTcuts.C(\"rates_${EPOCH}_ATM${ATM}.root\", \"$MVADIR\", 0, ${ENBINS}, 0, ${ZEBINS})" > ${PREDIR}/${CUT}/${CUT}_${EPOCH}_ATM${ATM}.optimised.dat
 
 exit

--- a/scripts/helper_scripts/IRF.optimizeTMVAforGammaHadronSeparation_sub.sh
+++ b/scripts/helper_scripts/IRF.optimizeTMVAforGammaHadronSeparation_sub.sh
@@ -9,7 +9,7 @@ source $EVNDISPSYS/setObservatory.sh VTS
 EFFAREA=EFFFILE
 PREDIR=ODIR
 CUT=CUTTYPE
-ETHRESH="1."
+DEADTIME="12."
 EPOCH=EEPOCH
 ATM=AATM
 ENBINS=EEBINS
@@ -44,7 +44,7 @@ rm -f ${MVADIR}/rates.log
 "$EVNDISPSYS"/bin/calculateCrabRateFromMC \
     ${EFFAREA} \
     ${RATEFILE}.root \
-    ${ETHRESH} \
+    ${DEADTIME} \
     ${VERITAS_EVNDISP_AUX_DIR}/ParameterFiles/TMVA.BDT.runparameter \
     ${TEMPDIR}/anasum.list \
     > ${RATEFILE}.log

--- a/scripts/helper_scripts/IRF.optimizeTMVAforGammaHadronSeparation_sub.sh
+++ b/scripts/helper_scripts/IRF.optimizeTMVAforGammaHadronSeparation_sub.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# script to calcualte signal and background rates and
+# optimize BDTs with TMVA
+#
+
+# set observatory environmental variables
+source $EVNDISPSYS/setObservatory.sh VTS
+
+EFFAREA=EFFFILE
+PREDIR=ODIR
+CUT=CUTTYPE
+ETHRESH="1."
+EPOCH=EEPOCH
+ATM=AATM
+ENBINS=EEBINS
+ZEBINS=ZZBINS
+
+if [[ -n $TMPDIR ]]; then
+    TEMPDIR=$TMPDIR/${CUT}
+else
+    TEMPDIR="$VERITAS_USER_DATA_DIR/TMPDIR/${CUT}/"
+fi
+echo "Temporary directory: $TEMPDIR"
+mkdir -p $TEMPDIR
+ls -1 ${PREDIR}/${CUT}/*.anasum.root > ${TEMPDIR}/anasum.list
+
+# effective area - fill path
+EFFAREA="$VERITAS_EVNDISP_AUX_DIR/EffectiveAreas/${EFFAREA}"
+
+# calculate rates from Crab Nebula and from background rates
+rm -f ${MVADIR}/rates.log
+"$EVNDISPSYS"/bin/calculateCrabRateFromMC \
+    ${EFFAREA} \
+    ${PREDIR}/${CUT}/rates_${EPOCH}_ATM${ATM}.root \
+    ${ETHRESH} \
+    ${VERITAS_EVNDISP_AUX_DIR}/ParameterFiles/TMVA.BDT.runparameter \
+    ${TEMPDIR}/anasum.list  > "${PREDIR}/${CUT}/rates_${EPOCH}_ATM${ATM}.log"
+
+# optimize cuts
+echo "optimize cuts..."
+MVADIR="$VERITAS_EVNDISP_AUX_DIR/GammaHadron_BDTs/${EPOCH}_ATM${ATM}/${CUT}/"
+cd ${PREDIR}/${CUT}
+rm -f ${PREDIR}/${CUT}/${CUT}.optimised.dat
+cd $EVNDISPSYS/macros/VTS/
+root -l -q -b "optimizeBDTcuts.C(\"rates_${EPOCH}_ATM${ATM}.root\", \"$MVADIR\", 0, ${ENBINS}, 0, ${ZEBINS})" > ${PREDIR}/${CUT}/${CUT}_${EPOCH}_ATM${ATM}.optimised.dat
+
+exit

--- a/scripts/helper_scripts/UTILITY.condorSubmission.sh
+++ b/scripts/helper_scripts/UTILITY.condorSubmission.sh
@@ -24,6 +24,8 @@ echo "request_memory = ${2}" >> ${SUBFIL}
 echo "request_disk = ${3}" >> ${SUBFIL}
 echo "getenv = True" >> ${SUBFIL}
 echo "max_materialize = 50" >> ${SUBFIL}
+# allow to prioritize jobs
+# echo "priority = 15" >> ${SUBFIL}
 if [ ! -z "$4" ]; then
     echo "queue ${4}" >> ${SUBFIL}
 else


### PR DESCRIPTION
This PR includes mostly improvements to scripts for gamma/hadron separation training and testing:
- energy energy binning definitions for TMVA training
- add cut optimisation analysis step
- improved run selection for TMVA training (background runs)

Other changes:
- addition of option `IGNOREIRF`
- addition of analysis type `AP_DISP`
- evndisp log files are now written into the root files (and log files deleted)