### PR TITLE
v490 - alpha.16 - work with zipped files for DBTEXT

### DIFF
--- a/scripts/ANALYSIS.evndisp.sh
+++ b/scripts/ANALYSIS.evndisp.sh
@@ -94,6 +94,8 @@ VPM=1
 DOWNLOAD=0
 # directory with DB text
 DBTEXTDIRECTORY="${VERITAS_DATA_DIR}/DBTEXT"
+# TODO
+DBTEXTDIRECTORY="/lustre/fs23/group/veritas/users/maierg/DBTEXT"
 
 echo "Using runparameter file $ACUTS ($EDVERSION, $VERITAS_ANALYSIS_TYPE)"
 
@@ -191,12 +193,12 @@ do
     FSCRIPT="$LOGDIR/EVN.data-${AFILE}${TIMESUFF}"
 
     if [[ ${AFILE} -lt 100000 ]]; then
-        DBRUNDIR="${DBTEXTDIRECTORY}/${AFILE:0:1}/${AFILE}"
+        DBRUNFIL="${DBTEXTDIRECTORY}/${AFILE:0:1}/${AFILE}.tar.gz"
     else
-        DBRUNDIR="${DBTEXTDIRECTORY}/${AFILE:0:2}/${AFILE}"
+        DBRUNFIL="${DBTEXTDIRECTORY}/${AFILE:0:2}/${AFILE}.tar.gz"
     fi
 
-    if [[ -d ${DBRUNDIR} ]] && [[ ${EDVERSION} != "v487" ]]; then
+    if [[ -e ${DBRUNFIL} ]] && [[ ${EDVERSION} != "v487" ]]; then
         DBTEXTDIR="${DBTEXTDIRECTORY}"
     else
         DBTEXTDIR="0"
@@ -274,8 +276,8 @@ do
         echo "TESTING SCRIPT $FSCRIPT.sh"
     fi
 
-    if [[ ! -d ${DBRUNDIR} ]] || [[ ${DBTEXTDIR} == "0" ]]; then
-        echo "SLEEPING (${SLEEPABIT}) ${DBRUNDIR}/$AFILE"
+    if [[ ! -e ${DBRUNFIL} ]] || [[ ${DBTEXTDIR} == "0" ]]; then
+        echo "SLEEPING (${SLEEPABIT}) ${DBRUNFIL} $AFILE"
         sleep ${SLEEPABIT}
     fi
 done

--- a/scripts/IRF.production.sh
+++ b/scripts/IRF.production.sh
@@ -148,9 +148,9 @@ elif [[ "${SIMTYPE}" = "CARE_June2020" ]]; then
     WOBBLE_OFFSETS=$(ls ${SIMDIR}/*/* | awk -F "_" '{print $7}' |  awk -F "wob" '{print $1}' | sort -u)
     ######################################
     # TEST
-    NSB_LEVELS=( 160 )
-    ZENITH_ANGLES=( 40 )
-    WOBBLE_OFFSETS=( 0.5 )
+    # NSB_LEVELS=( 160 )
+    # ZENITH_ANGLES=( 40 )
+    # WOBBLE_OFFSETS=( 0.5 )
     ######################################
     # TRAINMVANGRES production 
     # (assume 0.5 deg wobble is done)
@@ -207,6 +207,9 @@ else
              ANASUM.GammaHadron-Cut-NTel3-PointSource-Hard-TMVA-BDT.dat
              ANASUM.GammaHadron-Cut-NTel2-PointSource-Moderate.dat"
 fi
+# CUTLIST="ANASUM.GammaHadron-Cut-NTel2-PointSource-Moderate-TMVA-Preselection.dat
+#         ANASUM.GammaHadron-Cut-NTel2-PointSource-Soft-TMVA-Preselection.dat
+#         ANASUM.GammaHadron-Cut-NTel3-PointSource-Hard-TMVA-Preselection.dat"
 # CUTLIST="ANASUM.GammaHadron-Cut-NTel2-PointSource-Soft.dat"
 # CUTLIST="ANASUM.GammaHadron-Cut-NTel2-PointSource-Moderate.dat"
 # CUTLIST="ANASUM.GammaHadron-Cut-NTel2-PointSource-Moderate-TMVA-Preselection.dat"

--- a/scripts/helper_scripts/ANALYSIS.evndisp_sub.sh
+++ b/scripts/helper_scripts/ANALYSIS.evndisp_sub.sh
@@ -76,11 +76,39 @@ if [[ $DOWNLOAD == "1" ]] || [[ $DOWNLOAD == "2" ]]; then
    echo "DOWNLOAD STATUS $DOWNLOAD"
 fi
 
+unpack_db_textdirectory()
+{
+    RRUN=${1}
+    TMP_DBTEXTDIRECTORY=${2}
+    if [[ ${RRUN} -lt 100000 ]]; then
+        SRUN=${RRUN:0:1}
+    else
+        SRUN=${RRUN:0:2}
+    fi
+    DBRUNFIL="${DBTEXTDIRECTORY}/${SRUN}/${RRUN}.tar.gz"
+    if [[ -e ${DBRUNFIL} ]]; then
+        mkdir -p ${TMP_DBTEXTDIRECTORY}/${SRUN}
+        tar -xzf ${DBRUNFIL} -C ${TMP_DBTEXTDIRECTORY}/${SRUN}/
+    fi
+    echo "${TMP_DBTEXTDIRECTORY}/${SRUN}/${RRUN}/${RRUN}.laserrun"
+}
+
+# Unpack DBText information (replacement to DB calls)
 if [[ "${DBTEXTDIRECTORY}" != "0" ]]; then
-    OPT=( -dbtextdirectory ${DBTEXTDIRECTORY} -epochfile VERITAS.Epochs.runparameter )
+    TMP_DBTEXTDIRECTORY="${TEMPDIR}/DBTEXT"
+    TMP_LASERRUN=$(unpack_db_textdirectory $RUN $TMP_DBTEXTDIRECTORY)
+    LRUNID=$(cat ${TMP_LASERRUN} | grep -v run_id | awk -F "|" '{print $1}')
+    for LL in ${LRUNID}
+    do
+        echo "unpacking $LL"
+        unpack_db_textdirectory $LL $TMP_DBTEXTDIRECTORY
+    done
+    ls -l ${TMP_DBTEXTDIRECTORY}/6
+
+    OPT=( -dbtextdirectory ${TMP_DBTEXTDIRECTORY} -epochfile VERITAS.Epochs.runparameter )
+    echo "${OPT[@]}"
 fi
 
-        
 #########################################
 # pedestal calculation
 if [[ $CALIB == "1" || $CALIB == "2" || $CALIB == "4" || $CALIB == "5" ]]; then


### PR DESCRIPTION
Changes relative to alpha.15:

- EVNDISP scripts handle now zipped DBTEXT files (i.e., one file per run called e.g. 6/64080.tar.gz)