### PR TITLE
remove printAnasumRunParameter

### DIFF
--- a/scripts/helper_scripts/ANALYSIS.v2dl3_sub.sh
+++ b/scripts/helper_scripts/ANALYSIS.v2dl3_sub.sh
@@ -97,7 +97,7 @@ do
     fi
     echo "   ANASUM file: ${ANASUMFILE}"
 
-    result=$(python ${V2DL3}/utils/query_epoch_effective_area.py "$ANASUMFILE" $RUN)
+    result=$(python ${V2DL3}/utils/query_anasum_runparameters.py "$ANASUMFILE" $RUN)
     EPOCH=$(echo $result | cut -d',' -f1)
     EFFAREA=$(echo $result | cut -d',' -f2)
     echo "   Effective area file: $EFFAREA"

--- a/scripts/helper_scripts/ANALYSIS.v2dl3_sub.sh
+++ b/scripts/helper_scripts/ANALYSIS.v2dl3_sub.sh
@@ -96,9 +96,12 @@ do
         continue
     fi
     echo "   ANASUM file: ${ANASUMFILE}"
-    EFFAREA=$($EVNDISPSYS/bin/printAnasumRunParameter ${ANASUMFILE} ${RUN} -effareafile)
+
+    result=$(python -c "from ${V2DL3}/utils/query_anasum_runparameters import get_epoch_effective_area; get_epoch_effective_area(${RUN})")
+    EPOCH=$(echo $result | cut -d',' -f1)
+    EFFAREA=$(echo $result | cut -d',' -f2)
     echo "   Effective area file: $EFFAREA"
-    EPOCH=$($EVNDISPSYS/bin/printRunParameter ${ANASUMFILE} -epoch)
+
     DBFITSFILE=$(getNumberedDirectory $RUN $VERITAS_DATA_DIR/shared/DBFITS)/$RUN.db.fits.gz
     if [[ ! -e ${DBFITSFILE} ]]; then
         echo "DB File ${DBFITSFILE} not found"

--- a/scripts/helper_scripts/ANALYSIS.v2dl3_sub.sh
+++ b/scripts/helper_scripts/ANALYSIS.v2dl3_sub.sh
@@ -97,7 +97,7 @@ do
     fi
     echo "   ANASUM file: ${ANASUMFILE}"
 
-    result=$(python -c "from ${V2DL3}/utils/query_anasum_runparameters import get_epoch_effective_area; get_epoch_effective_area(${RUN})")
+    result=$(python ${V2DL3}/utils/query_epoch_effective_area.py "$ANASUMFILE" $RUN)
     EPOCH=$(echo $result | cut -d',' -f1)
     EFFAREA=$(echo $result | cut -d',' -f2)
     echo "   Effective area file: $EFFAREA"


### PR DESCRIPTION
Removes `printAnasumRunParameter` dependency and uses instead `query_anasum_runparameters` from `v2dl3`.