### PR TITLE
Refactor: shared job submission utility (eliminates duplication across 22 scripts)

### DIFF
--- a/docs/changes/148.maintenance.md
+++ b/docs/changes/148.maintenance.md
@@ -1,0 +1,1 @@
+Refactor job submission into shared utility (`UTILITY.submitJob.sh`), eliminating code duplication across 22 scripts and all remaining shellcheck SC2086 warnings.

--- a/scripts/ANALYSIS.anasum.sh
+++ b/scripts/ANALYSIS.anasum.sh
@@ -4,6 +4,8 @@
 # qsub parameters
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=8:00:00; h_vmem=4000M; tmpdir_size=10G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 if [[ $# -lt 3 ]]; then
 # begin help message
@@ -94,24 +96,10 @@ if [[ $SUBC == *"ERROR"* ]]; then
     echo "$SUBC"
     exit
 fi
+submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$LOGDIR/runscripts.$TIMETAG.dat"
+submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$LOGDIR/runscripts.$TIMETAG.dat"
 if [[ $SUBC == *qsub* ]]; then
-    # shellcheck disable=SC2086
-    JOBID=$($SUBC "$FSCRIPT".sh)
-
-    # account for -terse changing the job number format
-    if [[ $SUBC != *-terse* ]] ; then
-        echo "without -terse!"      # need to match VVVVVVVV  8539483  and 3843483.1-4:2
-        JOBID=$( echo "$JOBID" | grep -oP "Your job [0-9.-:]+" | awk '{ print $3 }' )
-    fi
     echo "RUN $AFILE JOBID $JOBID"
-elif [[ $SUBC == *condor* ]]; then
-    "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT.sh" "$h_vmem" "$tmpdir_size"
-    condor_submit "$FSCRIPT".sh.condor
-elif [[ $SUBC == *parallel* ]]; then
-    echo "$FSCRIPT.sh &> $FSCRIPT.log" >> "$LOGDIR"/runscripts."$TIMETAG".dat
-    # shellcheck disable=SC2086
-    cat "$LOGDIR"/runscripts."$TIMETAG".dat | $SUBC
-
-elif [[ $SUBC == *simple* ]]; then
-	"$FSCRIPT.sh" |& tee "$FSCRIPT".log
 fi
+run_parallel_jobs "$LOGDIR/runscripts.$TIMETAG.dat"
+run_parallel_jobs "$LOGDIR/runscripts.$TIMETAG.dat"

--- a/scripts/ANALYSIS.anasum.sh
+++ b/scripts/ANALYSIS.anasum.sh
@@ -97,9 +97,7 @@ if [[ $SUBC == *"ERROR"* ]]; then
     exit
 fi
 submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$LOGDIR/runscripts.$TIMETAG.dat"
-submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$LOGDIR/runscripts.$TIMETAG.dat"
 if [[ $SUBC == *qsub* ]]; then
     echo "RUN $AFILE JOBID $JOBID"
 fi
-run_parallel_jobs "$LOGDIR/runscripts.$TIMETAG.dat"
 run_parallel_jobs "$LOGDIR/runscripts.$TIMETAG.dat"

--- a/scripts/ANALYSIS.anasum_combine.sh
+++ b/scripts/ANALYSIS.anasum_combine.sh
@@ -4,6 +4,8 @@
 # qsub parameters
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=0:59:00; h_vmem=12000M; tmpdir_size=150G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 if [[ $# -lt 3 ]]; then
 # begin help message
@@ -98,28 +100,15 @@ if [[ $SUBC == *"ERROR"* ]]; then
     echo "$SUBC"
     exit
 fi
+RUNSCRIPT_LIST="$LOGDIR/runscripts.$(date +"%s").dat"
+submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$RUNSCRIPT_LIST"
+RUNSCRIPT_LIST="$LOGDIR/runscripts.$(date +"%s").dat"
+submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$RUNSCRIPT_LIST"
 if [[ $SUBC == *qsub* ]]; then
-    # shellcheck disable=SC2086
-    JOBID=$($SUBC "$FSCRIPT".sh)
-    # account for -terse changing the job number format
-    if [[ $SUBC != *-terse* ]] ; then
-        echo "without -terse!"      # need to match VVVVVVVV  8539483  and 3843483.1-4:2
-        JOBID=$( echo "$JOBID" | grep -oP "Your job [0-9.-:]+" | awk '{ print $3 }' )
-    fi
-elif [[ $SUBC == *condor* ]]; then
-    "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT.sh" "$h_vmem" "$tmpdir_size"
-    condor_submit "$FSCRIPT".sh.condor
-echo "OUTFILE $OUTFILE JOBID $JOBID"
+    echo "OUTFILE $OUTFILE JOBID $JOBID"
     echo "OUTFILE $OUTFILE SCRIPT $FSCRIPT.sh"
     if [[ $SUBC != */dev/null* ]] ; then
         echo "OUTFILE $OUTFILE OLOG $FSCRIPT.sh.o$JOBID"
         echo "OUTFILE $OUTFILE ELOG $FSCRIPT.sh.e$JOBID"
     fi
-elif [[ $SUBC == *sbatch* ]]; then
-    # shellcheck disable=SC2086
-    $SUBC "$FSCRIPT".sh
-elif [[ $SUBC == *parallel* ]]; then
-    echo "$FSCRIPT.sh &> $FSCRIPT.log" >> "$LOGDIR/runscripts.$(date +"%s").dat"
-elif [[ "$SUBC" == *simple* ]] ; then
-    "$FSCRIPT.sh" |& tee "$FSCRIPT.log"
 fi

--- a/scripts/ANALYSIS.anasum_combine.sh
+++ b/scripts/ANALYSIS.anasum_combine.sh
@@ -102,8 +102,6 @@ if [[ $SUBC == *"ERROR"* ]]; then
 fi
 RUNSCRIPT_LIST="$LOGDIR/runscripts.$(date +"%s").dat"
 submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$RUNSCRIPT_LIST"
-RUNSCRIPT_LIST="$LOGDIR/runscripts.$(date +"%s").dat"
-submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$RUNSCRIPT_LIST"
 if [[ $SUBC == *qsub* ]]; then
     echo "OUTFILE $OUTFILE JOBID $JOBID"
     echo "OUTFILE $OUTFILE SCRIPT $FSCRIPT.sh"

--- a/scripts/ANALYSIS.anasum_parallel_from_runlist.sh
+++ b/scripts/ANALYSIS.anasum_parallel_from_runlist.sh
@@ -300,6 +300,7 @@ for RUN in "${RUNS[@]}"; do
         echo "$SUBC"
         exit
     fi
+    CONDOR_SUBMIT_ARGS="submit 50"
     submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$TMPLOGDIR/runscripts.$TIMETAG.dat"
     if [[ $SUBC == *parallel* ]]; then
         echo "RUN $RUN OLOG $FSCRIPT.log"

--- a/scripts/ANALYSIS.anasum_parallel_from_runlist.sh
+++ b/scripts/ANALYSIS.anasum_parallel_from_runlist.sh
@@ -4,6 +4,8 @@
 # qsub parameters
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=0:59:00; h_vmem=4000M; tmpdir_size=1G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 # EventDisplay version
 EDVERSION=$(cat "$VERITAS_EVNDISP_AUX_DIR"/IRFVERSION)
@@ -298,33 +300,11 @@ for RUN in "${RUNS[@]}"; do
         echo "$SUBC"
         exit
     fi
-    if [[ $SUBC == *qsub* ]]; then
-        # shellcheck disable=SC2086
-        JOBID=$($SUBC "$FSCRIPT".sh)
-        # account for -terse changing the job number format
-        if [[ $SUBC != *-terse* ]] ; then
-            echo "without -terse!"      # need to match VVVVVVVV  8539483  and 3843483.1-4:2
-            JOBID=$( echo "$JOBID" | grep -oP "Your job [0-9.-:]+" | awk '{ print $3 }' )
-        fi
-    elif [[ $SUBC == *condor* ]]; then
-        "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT.sh" "$h_vmem" "$tmpdir_size"
-        echo
-        echo "$EVNDISPSCRIPTS/helper_scripts/submit_scripts_to_htcondor.sh ${TMPLOGDIR} submit 50"
-        echo "-------------------------------------------------------------------------------"
-        echo
-	elif [[ $SUBC == *sbatch* ]]; then
-        # shellcheck disable=SC2086
-        $SUBC "$FSCRIPT".sh
-    elif [[ $SUBC == *parallel* ]]; then
-        echo "$FSCRIPT.sh &> $FSCRIPT.log" >> "$TMPLOGDIR/runscripts.$TIMETAG.dat"
+    submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$TMPLOGDIR/runscripts.$TIMETAG.dat"
+    if [[ $SUBC == *parallel* ]]; then
         echo "RUN $RUN OLOG $FSCRIPT.log"
-    elif [[ "$SUBC" == *simple* ]] ; then
-	    "$FSCRIPT.sh" |& tee "$FSCRIPT.log"
-	fi
+    fi
 done
 
 # Execute all FSCRIPTs locally in parallel
-if [[ $SUBC == *parallel* ]]; then
-    # shellcheck disable=SC2086
-    cat "$LOGDIR/runscripts.$TIMETAG.dat" | $SUBC
-fi
+run_parallel_jobs "$TMPLOGDIR/runscripts.$TIMETAG.dat"

--- a/scripts/ANALYSIS.dispXGB.sh
+++ b/scripts/ANALYSIS.dispXGB.sh
@@ -4,6 +4,8 @@
 # qsub parameters
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=11:59:00; h_vmem=4000M; tmpdir_size=25G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 if [ "$#" -lt 3 ]; then
 echo "
@@ -77,21 +79,8 @@ do
 
     SUBC=$("$(dirname "$0")/helper_scripts/UTILITY.readSubmissionCommand.sh")
     SUBC=$(eval "echo \"$SUBC\"")
-    if [[ $SUBC == *condor* ]]; then
-        "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT.sh" "$h_vmem" "$tmpdir_size"
-        echo
-        echo "-------------------------------------------------------------------------------"
-        echo "Job submission using HTCondor - run the following script to submit jobs at once:"
-        echo "$EVNDISPSCRIPTS/helper_scripts/submit_scripts_to_htcondor.sh ${LOGDIR} submit"
-        echo "-------------------------------------------------------------------------------"
-        echo
-    elif [[ $SUBC == *sbatch* ]]; then
-        # shellcheck disable=SC2086
-        $SUBC "$FSCRIPT".sh
-    elif [[ $SUBC == *parallel* ]]; then
-        echo "$FSCRIPT.sh &> $FSCRIPT.log" >> "${LOGDIR}"/runscripts."$TIMETAG".dat
+    submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "${LOGDIR}/runscripts.$TIMETAG.dat"
+    if [[ $SUBC == *parallel* ]]; then
         echo "RUN $RUNN OLOG $FSCRIPT.log"
-    elif [[ "$SUBC" == *simple* ]] ; then
-       "$FSCRIPT.sh" |& tee "$FSCRIPT.log"
     fi
 done

--- a/scripts/ANALYSIS.evndisp.sh
+++ b/scripts/ANALYSIS.evndisp.sh
@@ -4,6 +4,8 @@
 # qsub parameters
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=11:59:00; h_vmem=4000M; tmpdir_size=25G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 # EventDisplay version
 EDVERSION=$(cat "$VERITAS_EVNDISP_AUX_DIR"/IRFVERSION)
@@ -252,40 +254,17 @@ do
             echo "read calibration from VOffline DB (default)"
     fi
 
-    if [[ $SUBC == *qsub* ]]; then
-        # shellcheck disable=SC2086
-        JOBID=$($SUBC "$FSCRIPT".sh)
-        # account for -terse changing the job number format
-        if [[ $SUBC != *-terse* ]] ; then
-            echo "without -terse!"      # need to match VVVVVVVV  8539483  and 3843483.1-4:2
-            JOBID=$( echo "$JOBID" | grep -oP "Your job [0-9.-:]+" | awk '{ print $3 }' )
+        submit_job "$FSCRIPT.sh" "$FSCRIPT.sh" "$LOGDIR/runscripts.sh"
+        if [[ $SUBC == *qsub* ]]; then
+            echo "RUN $FILE JOBID $JOBID"
+            echo "RUN $FILE SCRIPT $FSCRIPT.sh"
+            if [[ $SUBC != */dev/null* ]] ; then
+                echo "RUN $FILE OLOG $FSCRIPT.sh.o$JOBID"
+                echo "RUN $FILE ELOG $FSCRIPT.sh.e$JOBID"
+            fi
+        elif [[ $SUBC == *parallel* ]]; then
+            echo "RUN $FILE OLOG $FSCRIPT.log"
         fi
-
-        echo "RUN $FILE JOBID $JOBID"
-        echo "RUN $FILE SCRIPT $FSCRIPT.sh"
-        if [[ $SUBC != */dev/null* ]] ; then
-            echo "RUN $FILE OLOG $FSCRIPT.sh.o$JOBID"
-            echo "RUN $FILE ELOG $FSCRIPT.sh.e$JOBID"
-        fi
-    elif [[ $SUBC == *condor* ]]; then
-        "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT.sh" "$h_vmem" "$tmpdir_size"
-        echo
-        echo "-------------------------------------------------------------------------------"
-        echo "Job submission using HTCondor - run the following script to submit jobs at once:"
-        echo "$EVNDISPSCRIPTS/helper_scripts/submit_scripts_to_htcondor.sh ${LOGDIR} submit"
-        echo "-------------------------------------------------------------------------------"
-        echo
-    elif [[ $SUBC == *sbatch* ]]; then
-        # shellcheck disable=SC2086
-        $SUBC "$FSCRIPT".sh
-    elif [[ $SUBC == *parallel* ]]; then
-        echo "$FSCRIPT.sh" >> "$LOGDIR"/runscripts.sh
-        echo "RUN $FILE OLOG $FSCRIPT.log"
-    elif [[ "$SUBC" == *simple* ]] ; then
-        "$FSCRIPT.sh" | tee "$FSCRIPT.log"
-    elif [[ "$SUBC" == *test* ]]; then
-        echo "TESTING SCRIPT $FSCRIPT.sh"
-    fi
 
     if [[ ! -e ${DBRUNFIL} ]] || [[ ${DBTEXTDIR} == "0" ]]; then
         echo "SLEEPING (${SLEEPABIT}) ${DBRUNFIL} $FILE"
@@ -303,8 +282,7 @@ if [[ $SUBC == *parallel* ]]; then
         echo "echo \"==================================\""
         echo "echo \"List of scripts to run\""
         cat "$LOGDIR"/runscripts.sh | sort -u | awk "{print \$1}" | sed 's/.*/echo \" & \"/'
-        # shellcheck disable=SC2086
-        echo "cat $LOGDIR/runscripts.sh | sort -u | $SUBC"
+        echo "run_parallel_jobs \"$LOGDIR/runscripts.sh\""
     } >> Run_me.sh
     chmod +x Run_me.sh
 # shellcheck source=/dev/null

--- a/scripts/ANALYSIS.evndisp_laser.sh
+++ b/scripts/ANALYSIS.evndisp_laser.sh
@@ -4,6 +4,8 @@
 # qsub parameters
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=11:29:00; h_vmem=2000M; tmpdir_size=5G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 if [ ! -n "$1" ] || [ "$1" = "-h" ]; then
 # begin help message
@@ -90,34 +92,13 @@ for RUN in $RUNNUMS; do
     # run locally or on cluster
     SUBC=$("$(dirname "$0")/helper_scripts/UTILITY.readSubmissionCommand.sh")
     SUBC=$(eval "echo \"$SUBC\"")
-    if [[ $SUBC == *qsub* ]]; then
-        # shellcheck disable=SC2086
-        JOBID=$($SUBC "$FSCRIPT".sh)
-
-        # account for -terse changing the job number format
-        if [[ $SUBC != *-terse* ]] ; then
-            echo "without -terse!"      # need to match VVVVVVVV  8539483  and 3843483.1-4:2
-            JOBID=$( echo "$JOBID" | grep -oP "Your job [0-9.-:]+" | awk '{ print $3 }' )
+        submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$LOGDIR/runscripts.dat"
+        if [[ $SUBC == *qsub* ]]; then
+            echo "RUN $RUN: JOBID $JOBID"
         fi
-
-        echo "RUN $RUN: JOBID $JOBID"
-    elif [[ $SUBC == *condor* ]]; then
-        "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT.sh" "$h_vmem" "$tmpdir_size"
-        condor_submit "$FSCRIPT".sh.condor
-    elif [[ $SUBC == *sbatch* ]]; then
-        # shellcheck disable=SC2086
-        $SUBC "$FSCRIPT".sh
-    elif [[ $SUBC == *parallel* ]]; then
-        echo "$FSCRIPT.sh &> $FSCRIPT.log" >> "$LOGDIR"/runscripts.dat
-    elif [[ "$SUBC" == *simple* ]] ; then
-        "$FSCRIPT.sh" |& tee "$FSCRIPT.log"
-    fi
 done
 
 # Execute all FSCRIPTs locally in parallel
-if [[ $SUBC == *parallel* ]]; then
-    # shellcheck disable=SC2086
-    cat "$LOGDIR"/runscripts.dat | $SUBC
-fi
+run_parallel_jobs "$LOGDIR/runscripts.dat"
 
 exit

--- a/scripts/ANALYSIS.evndisp_muon.sh
+++ b/scripts/ANALYSIS.evndisp_muon.sh
@@ -4,6 +4,8 @@
 # qsub parameters
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=11:59:00; h_vmem=2000M; tmpdir_size=25G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 # EventDisplay version
 EDVERSION=$("$EVNDISPSYS"/bin/evndisp --version | tr -d .)
@@ -171,39 +173,20 @@ do
     # run locally or on cluster
     SUBC=$("$(dirname "$0")/helper_scripts/UTILITY.readSubmissionCommand.sh")
     SUBC=$(eval "echo \"$SUBC\"")
-    if [[ $SUBC == *qsub* ]]; then
-        # shellcheck disable=SC2086
-        JOBID=$($SUBC "$FSCRIPT".sh)
-        # account for -terse changing the job number format
-        if [[ $SUBC != *-terse* ]] ; then
-            echo "without -terse!"      # need to match VVVVVVVV  8539483  and 3843483.1-4:2
-            JOBID=$( echo "$JOBID" | grep -oP "Your job [0-9.-:]+" | awk '{ print $3 }' )
+        submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$LOGDIR/runscripts.$TIMETAG.dat"
+        if [[ $SUBC == *qsub* ]]; then
+            echo "RUN $AFILE JOBID $JOBID"
+            echo "RUN $AFILE SCRIPT $FSCRIPT.sh"
+            if [[ $SUBC != */dev/null* ]] ; then
+                echo "RUN $AFILE OLOG $FSCRIPT.sh.o$JOBID"
+                echo "RUN $AFILE ELOG $FSCRIPT.sh.e$JOBID"
+            fi
+        elif [[ $SUBC == *parallel* ]]; then
+            echo "RUN $AFILE OLOG $FSCRIPT.log"
         fi
-
-        echo "RUN $AFILE JOBID $JOBID"
-        echo "RUN $AFILE SCRIPT $FSCRIPT.sh"
-        if [[ $SUBC != */dev/null* ]] ; then
-            echo "RUN $AFILE OLOG $FSCRIPT.sh.o$JOBID"
-            echo "RUN $AFILE ELOG $FSCRIPT.sh.e$JOBID"
-        fi
-    elif [[ $SUBC == *condor* ]]; then
-        "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT.sh" "$h_vmem" "$tmpdir_size"
-        condor_submit "$FSCRIPT".sh.condor
-    elif [[ $SUBC == *sbatch* ]]; then
-        # shellcheck disable=SC2086
-        $SUBC "$FSCRIPT".sh
-    elif [[ $SUBC == *parallel* ]]; then
-        echo "$FSCRIPT.sh &> $FSCRIPT.log" >> "$LOGDIR"/runscripts."$TIMETAG".dat
-        echo "RUN $AFILE OLOG $FSCRIPT.log"
-    elif [[ "$SUBC" == *simple* ]] ; then
-	"$FSCRIPT.sh" |& tee "$FSCRIPT.log"
-    fi
 done
 
 # Execute all FSCRIPTs locally in parallel
-if [[ $SUBC == *parallel* ]]; then
-    # shellcheck disable=SC2086
-    cat "$LOGDIR"/runscripts."$TIMETAG".dat | sort -u | $SUBC
-fi
+run_parallel_jobs "$LOGDIR/runscripts.$TIMETAG.dat"
 
 exit

--- a/scripts/ANALYSIS.mscw_energy.sh
+++ b/scripts/ANALYSIS.mscw_energy.sh
@@ -4,6 +4,8 @@
 # qsub parameters
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=00:29:00; h_vmem=4000M; tmpdir_size=4G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 # EventDisplay version
 EDVERSION=$(cat "$VERITAS_EVNDISP_AUX_DIR"/IRFVERSION)
@@ -151,44 +153,20 @@ do
     SUBC=$("$(dirname "$0")/helper_scripts/UTILITY.readSubmissionCommand.sh")
     SUBC=$(eval "echo \"$SUBC\"")
     echo "Submission command: $SUBC"
-    if [[ $SUBC == *qsub* ]]; then
-        # shellcheck disable=SC2086
-        JOBID=$($SUBC "$FSCRIPT".sh)
-        # account for -terse changing the job number format
-        if [[ $SUBC != *-terse* ]] ; then
-            echo "without -terse!"      # need to match VVVVVVVV  8539483  and 3843483.1-4:2
-            JOBID=$( echo "$JOBID" | grep -oP "Your job [0-9.-:]+" | awk '{ print $3 }' )
+        submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$TMPLOGDIR/runscripts.$TIMETAG.dat"
+        if [[ $SUBC == *qsub* ]]; then
+            echo "RUN $RUNN JOBID $JOBID"
+            echo "RUN $RUNN SCRIPT $FSCRIPT.sh"
+            if [[ $SUBC != */dev/null* ]] ; then
+                echo "RUN $RUNN OLOG $FSCRIPT.sh.o$JOBID"
+                echo "RUN $RUNN ELOG $FSCRIPT.sh.e$JOBID"
+            fi
+        elif [[ $SUBC == *parallel* ]]; then
+            echo "RUN $RUNN OLOG $FSCRIPT.log"
         fi
-
-        echo "RUN $RUNN JOBID $JOBID"
-        echo "RUN $RUNN SCRIPT $FSCRIPT.sh"
-        if [[ $SUBC != */dev/null* ]] ; then
-            echo "RUN $RUNN OLOG $FSCRIPT.sh.o$JOBID"
-            echo "RUN $RUNN ELOG $FSCRIPT.sh.e$JOBID"
-        fi
-    elif [[ $SUBC == *condor* ]]; then
-        "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT.sh" "$h_vmem" "$tmpdir_size"
-        echo
-        echo "-------------------------------------------------------------------------------"
-        echo "Job submission using HTCondor - run the following script to submit jobs at once:"
-        echo "$EVNDISPSCRIPTS/helper_scripts/submit_scripts_to_htcondor.sh ${TMPLOGDIR} submit"
-        echo "-------------------------------------------------------------------------------"
-        echo
-    elif [[ $SUBC == *sbatch* ]]; then
-        # shellcheck disable=SC2086
-        $SUBC "$FSCRIPT".sh
-    elif [[ $SUBC == *parallel* ]]; then
-        echo "$FSCRIPT.sh &> $FSCRIPT.log" >> "${TMPLOGDIR}"/runscripts."$TIMETAG".dat
-        echo "RUN $RUNN OLOG $FSCRIPT.log"
-    elif [[ "$SUBC" == *simple* ]] ; then
-        "$FSCRIPT.sh" |& tee "$FSCRIPT.log"
-    fi
 done
 
 # Execute all FSCRIPTs locally in parallel
-if [[ $SUBC == *parallel* ]]; then
-    # shellcheck disable=SC2086
-    cat "$TMPLOGDIR"/runscripts."$TIMETAG".dat | $SUBC
-fi
+run_parallel_jobs "$TMPLOGDIR/runscripts.$TIMETAG.dat"
 
 echo "LOG/SUBMIT DIR: ${TMPLOGDIR}"

--- a/scripts/ANALYSIS.v2dl3.sh
+++ b/scripts/ANALYSIS.v2dl3.sh
@@ -7,6 +7,8 @@
 # qsub parameters
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=11:59:00; h_vmem=4000M; tmpdir_size=25G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 if [ "$#" -lt 3 ]; then
 echo "
@@ -91,42 +93,18 @@ do
         echo "$SUBC"
         exit
     fi
-    if [[ $SUBC == *qsub* ]]; then
-        # shellcheck disable=SC2086
-        JOBID=$($SUBC "$FSCRIPT".sh)
-        # account for -terse changing the job number format
-        if [[ $SUBC != *-terse* ]] ; then
-            echo "without -terse!"      # need to match VVVVVVVV  8539483  and 3843483.1-4:2
-            JOBID=$( echo "$JOBID" | grep -oP "Your job [0-9.-:]+" | awk '{ print $3 }' )
+        submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$LOGDIR/runscripts.$TIMETAG.dat"
+        if [[ $SUBC == *qsub* ]]; then
+            echo "RUN $J JOBID $JOBID"
+            echo "RUN $J SCRIPT $FSCRIPT.sh"
+            if [[ $SUBC != */dev/null* ]] ; then
+                echo "RUN $J OLOG $FSCRIPT.sh.o$JOBID"
+                echo "RUN $J ELOG $FSCRIPT.sh.e$JOBID"
+            fi
+        elif [[ $SUBC == *parallel* ]]; then
+            echo "RUN $J OLOG $FSCRIPT.log"
         fi
-
-        echo "RUN $J JOBID $JOBID"
-        echo "RUN $J SCRIPT $FSCRIPT.sh"
-        if [[ $SUBC != */dev/null* ]] ; then
-            echo "RUN $J OLOG $FSCRIPT.sh.o$JOBID"
-            echo "RUN $J ELOG $FSCRIPT.sh.e$JOBID"
-        fi
-    elif [[ $SUBC == *condor* ]]; then
-        "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT.sh" "$h_vmem" "$tmpdir_size"
-        echo
-        echo "-------------------------------------------------------------------------------"
-        echo "Job submission using HTCondor - run the following script to submit jobs at once:"
-        echo "$EVNDISPSCRIPTS/helper_scripts/submit_scripts_to_htcondor.sh ${LOGDIR} submit 5"
-        echo "-------------------------------------------------------------------------------"
-        echo
-	elif [[ $SUBC == *sbatch* ]]; then
-        # shellcheck disable=SC2086
-        $SUBC "$FSCRIPT".sh
-    elif [[ $SUBC == *parallel* ]]; then
-        echo "$FSCRIPT.sh &> $FSCRIPT.log" >> "$LOGDIR/runscripts.$TIMETAG.dat"
-        echo "RUN $J OLOG $FSCRIPT.log"
-    elif [[ "$SUBC" == *simple* ]] ; then
-	    "$FSCRIPT.sh" |& tee "$FSCRIPT.log"
-	fi
 done
 
 # Execute all FSCRIPTs locally in parallel
-if [[ $SUBC == *parallel* ]]; then
-    # shellcheck disable=SC2086
-    cat "$LOGDIR/runscripts.$TIMETAG.dat" | $SUBC
-fi
+run_parallel_jobs "$LOGDIR/runscripts.$TIMETAG.dat"

--- a/scripts/ANALYSIS.v2dl3.sh
+++ b/scripts/ANALYSIS.v2dl3.sh
@@ -93,6 +93,7 @@ do
         echo "$SUBC"
         exit
     fi
+        CONDOR_SUBMIT_ARGS="submit 5"
         submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$LOGDIR/runscripts.$TIMETAG.dat"
         if [[ $SUBC == *qsub* ]]; then
             echo "RUN $J JOBID $JOBID"

--- a/scripts/IRF.combine_effective_area_parts.sh
+++ b/scripts/IRF.combine_effective_area_parts.sh
@@ -4,6 +4,8 @@
 # job requirements
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=11:29:00; h_vmem=12000M; tmpdir_size=20G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 #
 # EventDisplay version
 EDVERSION=$(cat "$VERITAS_EVNDISP_AUX_DIR"/IRFVERSION)
@@ -143,24 +145,8 @@ if [[ $SUBC == *"ERROR"* ]]; then
     echo "$SUBC"
     exit
 fi
+submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$LOGDIR/runscripts.dat"
 if [[ $SUBC == *qsub* ]]; then
-    # shellcheck disable=SC2086
-    JOBID=$($SUBC "$FSCRIPT".sh)
     echo "JOBID: $JOBID"
-elif [[ $SUBC == *condor* ]]; then
-    "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT.sh" "$h_vmem" "$tmpdir_size"
-    echo
-    echo "-------------------------------------------------------------------------------"
-    echo "Job submission using HTCondor - run the following script to submit jobs at once:"
-    echo "$EVNDISPSCRIPTS/helper_scripts/submit_scripts_to_htcondor.sh ${LOGDIR} submit"
-    echo "-------------------------------------------------------------------------------"
-    echo
-elif [[ $SUBC == *sbatch* ]]; then
-    # shellcheck disable=SC2086
-    $SUBC "$FSCRIPT".sh
-elif [[ $SUBC == *parallel* ]]; then
-    echo "$FSCRIPT.sh &> $FSCRIPT.log" >> "$LOGDIR/runscripts.dat"
-elif [[ "$SUBC" == *simple* ]]; then
-    "$FSCRIPT.sh" | tee "$FSCRIPT.log"
 fi
 echo "LOG/SUBMIT DIR: ${LOGDIR}"

--- a/scripts/IRF.combine_lookup_table_parts.sh
+++ b/scripts/IRF.combine_lookup_table_parts.sh
@@ -4,6 +4,8 @@
 # job requirements
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=20:29:00; h_vmem=12000M; tmpdir_size=10G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 # EventDisplay version
 EDVERSION=$(cat "$VERITAS_EVNDISP_AUX_DIR"/IRFVERSION)
@@ -116,19 +118,8 @@ if [[ $SUBC == *"ERROR"* ]]; then
     echo "$SUBC"
     exit
 fi
+submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$LOGDIR/runscripts.dat"
 if [[ $SUBC == *qsub* ]]; then
-    # shellcheck disable=SC2086
-    JOBID=$($SUBC "$FSCRIPT".sh)
     echo "JOBID: $JOBID"
-elif [[ $SUBC == *condor* ]]; then
-    "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT.sh" "$h_vmem" "$tmpdir_size"
-    echo
-    echo "-------------------------------------------------------------------------------"
-    echo "Job submission using HTCondor - run the following script to submit jobs at once:"
-    echo "$EVNDISPSCRIPTS/helper_scripts/submit_scripts_to_htcondor.sh ${LOGDIR} submit"
-    echo "-------------------------------------------------------------------------------"
-    echo
-elif [[ $SUBC == *parallel* ]]; then
-    echo "$FSCRIPT.sh &> $FSCRIPT.log" >> "$LOGDIR"/runscripts.dat
 fi
 echo "LOG/SUBMIT DIR: ${LOGDIR}"

--- a/scripts/IRF.compress_evndisp_MC.sh
+++ b/scripts/IRF.compress_evndisp_MC.sh
@@ -5,6 +5,8 @@
 # qsub parameters
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=0:29:00; h_vmem=4000M; tmpdir_size=20G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 if [ $# -lt 7 ]; then
 # begin help message
@@ -221,21 +223,10 @@ do
     SUBC=$("$(dirname "$0")/helper_scripts/UTILITY.readSubmissionCommand.sh")
     SUBC=$(eval "echo \"$SUBC\"")
     echo "$SUBC"
-    if [[ $SUBC == *qsub* ]]; then
-        # shellcheck disable=SC2086
-        JOBID=$($SUBC "$FSCRIPT".sh)
-        echo "RUN $RUNNUM: JOBID $JOBID"
-    elif [[ $SUBC == *condor* ]]; then
-        "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT.sh" "$h_vmem" "$tmpdir_size"
-        echo
-        echo "-------------------------------------------------------------------------------"
-        echo "Job submission using HTCondor - run the following script to submit jobs at once:"
-        echo "$EVNDISPSCRIPTS/helper_scripts/submit_scripts_to_htcondor.sh ${LOGDIR} submit"
-        echo "-------------------------------------------------------------------------------"
-        echo
-    elif [[ $SUBC == *parallel* ]]; then
-        echo "$FSCRIPT.sh &> $FSCRIPT.log" >> "$LOGDIR"/runscripts.dat
-    fi
+        submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$LOGDIR/runscripts.dat"
+        if [[ $SUBC == *qsub* ]]; then
+            echo "RUN $RUNNUM: JOBID $JOBID"
+        fi
 done
 echo "LOG/SUBMIT DIR: ${LOGDIR}"
 

--- a/scripts/IRF.generate_effective_area_parts.sh
+++ b/scripts/IRF.generate_effective_area_parts.sh
@@ -5,6 +5,8 @@
 # qsub parameters
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=13:29:00; h_vmem=8000M; tmpdir_size=20G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 # EventDisplay version
 IRFVERSION=$(cat "$VERITAS_EVNDISP_AUX_DIR"/IRFVERSION)
@@ -124,21 +126,7 @@ if [[ $SUBC == *"ERROR"* ]]; then
     echo "Error: reading submission type from $SUBMISSION_SCRIPT"
     exit 1
 fi
+submit_job "$FSCRIPT" "$FSCRIPT &> $(basename "$FSCRIPT" .sh).log" "$LOGDIR/runscripts.dat"
 if [[ $SUBC == *qsub* ]]; then
-    # shellcheck disable=SC2086
-    JOBID=$($SUBC "$FSCRIPT")
     echo "JOBID: $JOBID"
-elif [[ $SUBC == *condor* ]]; then
-    "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT" "$h_vmem" "$tmpdir_size"
-    echo "-------------------------------------------------------------------------------"
-    echo "Job submission using HTCondor - run the following script to submit jobs:"
-    echo "$EVNDISPSCRIPTS/helper_scripts/submit_scripts_to_htcondor.sh ${LOGDIR} submit"
-    echo "-------------------------------------------------------------------------------"
-elif [[ $SUBC == *sbatch* ]]; then
-    # shellcheck disable=SC2086
-    $SUBC "$FSCRIPT"
-elif [[ $SUBC == *parallel* ]]; then
-    echo "$FSCRIPT &> $(basename "$FSCRIPT" .sh).log" >> "$LOGDIR/runscripts.dat"
-elif [[ "$SUBC" == *simple* ]]; then
-    "$FSCRIPT" | tee "$(basename "$FSCRIPT" .sh).log"
 fi

--- a/scripts/IRF.generate_lookup_table_parts.sh
+++ b/scripts/IRF.generate_lookup_table_parts.sh
@@ -5,6 +5,8 @@
 # qsub parameters
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=03:29:00; h_vmem=12000M; tmpdir_size=20G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 # EventDisplay version
 EDVERSION=$(cat "$VERITAS_EVNDISP_AUX_DIR"/IRFVERSION)
@@ -111,21 +113,7 @@ if [[ $SUBC == *"ERROR"* ]]; then
     echo "Error: reading submission type from $SUBMISSION_SCRIPT"
     exit 1
 fi
+submit_job "$FSCRIPT" "$FSCRIPT &> $FSCRIPT.log" "$LOGDIR/runscripts.dat"
 if [[ $SUBC == *qsub* ]]; then
-    # shellcheck disable=SC2086
-    JOBID=$($SUBC "$FSCRIPT")
     echo "JOBID: $JOBID"
-elif [[ $SUBC == *condor* ]]; then
-    "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT" "$h_vmem" "$tmpdir_size"
-    echo "-------------------------------------------------------------------------------"
-    echo "Job submission using HTCondor - run the following script to submit jobs:"
-    echo "$EVNDISPSCRIPTS/helper_scripts/submit_scripts_to_htcondor.sh ${LOGDIR} submit"
-    echo "-------------------------------------------------------------------------------"
-elif [[ $SUBC == *sbatch* ]]; then
-    # shellcheck disable=SC2086
-    $SUBC "$FSCRIPT"
-elif [[ $SUBC == *parallel* ]]; then
-    echo "$FSCRIPT &> $FSCRIPT.log" >> "$LOGDIR/runscripts.dat"
-elif [[ "$SUBC" == *simple* ]]; then
-    "$FSCRIPT" | tee "$FSCRIPT.log"
 fi

--- a/scripts/IRF.generate_radial_acceptance.sh
+++ b/scripts/IRF.generate_radial_acceptance.sh
@@ -4,6 +4,8 @@
 # qsub parameters
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=04:29:00; h_vmem=6000M; tmpdir_size=10G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 if [[ $# != 6 ]]; then
 # begin help message
@@ -158,26 +160,16 @@ for CUTS in "${CUTLIST[@]}"; do
             fi
             if [[ $SUBC == *qsub* ]]; then
                 echo "$SUBC" "$FSCRIPT.sh"
-                # shellcheck disable=SC2086
-                JOBID=$($SUBC "$FSCRIPT".sh)
+            fi
+            submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$LOGDIR/runscripts.dat"
+            if [[ $SUBC == *qsub* ]]; then
                 echo "JOBID: $JOBID"
-            elif [[ $SUBC == *condor* ]]; then
-                "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT.sh" "$h_vmem" "$tmpdir_size"
-                condor_submit "$FSCRIPT".sh.condor
-            elif [[ $SUBC == *sbatch* ]]; then
-                # shellcheck disable=SC2086
-                $SUBC "$FSCRIPT".sh
-            elif [[ $SUBC == *parallel* ]]; then
-                echo "$FSCRIPT.sh &> $FSCRIPT.log" >> "$LOGDIR"/runscripts.dat
             fi
         done
     done
 done
 
 # Execute all FSCRIPTs locally in parallel
-if [[ $SUBC == *parallel* ]]; then
-    # shellcheck disable=SC2086
-    cat "$LOGDIR/runscripts.dat" | $SUBC
-fi
+    run_parallel_jobs "$LOGDIR/runscripts.dat"
 
 exit

--- a/scripts/IRF.mscw_energy_MC.sh
+++ b/scripts/IRF.mscw_energy_MC.sh
@@ -5,6 +5,8 @@
 # qsub parameters
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=10:29:00; h_vmem=12000M; tmpdir_size=100G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 # EventDisplay version
 EDVERSION=$(cat "$VERITAS_EVNDISP_AUX_DIR"/IRFVERSION)
@@ -136,21 +138,7 @@ if [[ $SUBC == *"ERROR"* ]]; then
     echo "Error: reading submission type from $SUBMISSION_SCRIPT"
     exit 1
 fi
+submit_job "$FSCRIPT" "$FSCRIPT &> $FSCRIPT.log" "$LOGDIR/runscripts.dat"
 if [[ $SUBC == *qsub* ]]; then
-    # shellcheck disable=SC2086
-    JOBID=$($SUBC "$FSCRIPT")
     echo "JOBID: $JOBID"
-elif [[ $SUBC == *condor* ]]; then
-    "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT" "$h_vmem" "$tmpdir_size"
-    echo "-------------------------------------------------------------------------------"
-    echo "Job submission using HTCondor - run the following script to submit jobs:"
-    echo "$EVNDISPSCRIPTS/helper_scripts/submit_scripts_to_htcondor.sh ${LOGDIR} submit"
-    echo "-------------------------------------------------------------------------------"
-elif [[ $SUBC == *sbatch* ]]; then
-    # shellcheck disable=SC2086
-    $SUBC "$FSCRIPT"
-elif [[ $SUBC == *parallel* ]]; then
-    echo "$FSCRIPT &> $FSCRIPT.log" >> "$LOGDIR/runscripts.dat"
-elif [[ "$SUBC" == *simple* ]]; then
-    "$FSCRIPT" | tee "$FSCRIPT.log"
 fi

--- a/scripts/IRF.optimizeTMVAforGammaHadronSeparation.sh
+++ b/scripts/IRF.optimizeTMVAforGammaHadronSeparation.sh
@@ -5,6 +5,8 @@
 
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=11:59:59; h_vmem=4000M; tmpdir_size=1G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 if [[ $# -lt 5 ]]; then
 # begin help message
@@ -120,25 +122,8 @@ if [[ $SUBC == *"ERROR"* ]]; then
     echo "$SUBC"
     exit
 fi
+submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$LOGDIR/runscripts.dat"
 if [[ $SUBC == *qsub* ]]; then
- # shellcheck disable=SC2086
- JOBID=$($SUBC "$FSCRIPT".sh)
- # account for -terse changing the job number format
- if [[ $SUBC != *-terse* ]] ; then
-    echo "without -terse!"      # need to match VVVVVVVV  8539483  and 3843483.1-4:2
-    JOBID=$( echo "$JOBID" | grep -oP "Your job [0-9.-:]+" | awk '{ print $3 }' )
- fi
  echo "JOBID:  $JOBID"
-elif [[ $SUBC == *condor* ]]; then
-   "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT.sh" "$h_vmem" "$tmpdir_size"
-   condor_submit "$FSCRIPT".sh.condor
-elif [[ $SUBC == *sbatch* ]]; then
-    # shellcheck disable=SC2086
-    $SUBC "$FSCRIPT".sh
-elif [[ $SUBC == *parallel* ]]; then
-    echo "$FSCRIPT.sh &> $FSCRIPT.log" >> "$LOGDIR"/runscripts.dat
-    # shellcheck disable=SC2086
-    cat "$LOGDIR"/runscripts.dat | $SUBC
-elif [[ "$SUBC" == *simple* ]] ; then
-    "$FSCRIPT.sh" | tee "$FSCRIPT.log"
 fi
+run_parallel_jobs "$LOGDIR/runscripts.dat"

--- a/scripts/IRF.trainTMVAforAngularReconstruction.sh
+++ b/scripts/IRF.trainTMVAforAngularReconstruction.sh
@@ -4,6 +4,8 @@
 # qsub parameters
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=47:29:00; h_vmem=16000M; tmpdir_size=100G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 # EventDisplay version
 EDVERSION=$(cat "$VERITAS_EVNDISP_AUX_DIR"/IRFVERSION)
@@ -140,23 +142,9 @@ do
             echo "$SUBC"
             exit
         fi
-        if [[ $SUBC == *qsub* ]]; then
-            # shellcheck disable=SC2086
-            JOBID=$($SUBC "$FSCRIPT")
-            echo "RUN $RUNNUM: JOBID $JOBID"
-        elif [[ $SUBC == *condor* ]]; then
-            "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT" "$h_vmem" "$tmpdir_size"
-            echo
-            echo "-------------------------------------------------------------------------------"
-            echo "Job submission using HTCondor - run the following script to submit jobs at once:"
-            echo "$EVNDISPSCRIPTS/helper_scripts/submit_scripts_to_htcondor.sh ${LOGDIR} submit"
-            echo "-------------------------------------------------------------------------------"
-            echo
-        elif [[ $SUBC == *sbatch* ]]; then
-                # shellcheck disable=SC2086
-                $SUBC "$FSCRIPT"
-        elif [[ $SUBC == *parallel* ]]; then
-            echo "$FSCRIPT &> $FSCRIPT.log" >> "$LOGDIR/runscripts.dat"
-        fi
+            submit_job "$FSCRIPT" "$FSCRIPT &> $FSCRIPT.log" "$LOGDIR/runscripts.dat"
+            if [[ $SUBC == *qsub* ]]; then
+                echo "RUN $RUNNUM: JOBID $JOBID"
+            fi
     done
 done

--- a/scripts/IRF.trainTMVAforGammaHadronSeparation.sh
+++ b/scripts/IRF.trainTMVAforGammaHadronSeparation.sh
@@ -9,6 +9,8 @@
 
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=11:59:59; h_vmem=8000M; tmpdir_size=24G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 EDVERSION=$(cat "$VERITAS_EVNDISP_AUX_DIR"/IRFVERSION)
 
 if [ $# -lt 7 ]; then
@@ -266,32 +268,10 @@ do
             echo "$SUBC"
             exit
       fi
-      if [[ $SUBC == *qsub* ]]; then
-         # shellcheck disable=SC2086
-         JOBID=$($SUBC "$FSCRIPT".sh)
-         # account for -terse changing the job number format
-         if [[ $SUBC != *-terse* ]] ; then
-            echo "without -terse!"      # need to match VVVVVVVV  8539483  and 3843483.1-4:2
-            JOBID=$( echo "$JOBID" | grep -oP "Your job [0-9.-:]+" | awk '{ print $3 }' )
-         fi
-         echo "JOBID:  $JOBID"
-      elif [[ $SUBC == *condor* ]]; then
-        "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT.sh" "$h_vmem" "$tmpdir_size"
-        echo
-        echo "-------------------------------------------------------------------------------"
-        echo "Job submission using HTCondor - run the following script to submit jobs at once:"
-        echo "$EVNDISPSCRIPTS/helper_scripts/submit_scripts_to_htcondor.sh ${LOGDIR} submit"
-        echo "-------------------------------------------------------------------------------"
-        echo
-      elif [[ $SUBC == *sbatch* ]]; then
-            # shellcheck disable=SC2086
-            $SUBC "$FSCRIPT".sh
-      elif [[ $SUBC == *parallel* ]]; then
-         echo "$FSCRIPT.sh &> $FSCRIPT.log" >> "$LOGDIR"/runscripts.dat
-         # shellcheck disable=SC2086
-         cat "$LOGDIR"/runscripts.dat | $SUBC
-      elif [[ "$SUBC" == *simple* ]] ; then
-         "$FSCRIPT.sh" | tee "$FSCRIPT.log"
-      fi
+        submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$LOGDIR/runscripts.dat"
+        if [[ $SUBC == *qsub* ]]; then
+            echo "JOBID:  $JOBID"
+        fi
+        run_parallel_jobs "$LOGDIR/runscripts.dat"
    done
 done

--- a/scripts/IRF.trainXGBforAngularReconstructionBinned.sh
+++ b/scripts/IRF.trainXGBforAngularReconstructionBinned.sh
@@ -3,6 +3,8 @@
 
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=47:29:00; h_vmem=16000M; tmpdir_size=100G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 EDVERSION=$(cat "$VERITAS_EVNDISP_AUX_DIR"/IRFVERSION)
 
@@ -117,21 +119,7 @@ if [[ $SUBC == *"ERROR"* ]]; then
     echo "$SUBC"
     exit
 fi
-if [[ $SUBC == *qsub* ]]; then
-    # shellcheck disable=SC2086
-    JOBID=$($SUBC "$FSCRIPT")
-    echo "RUN $RUNNUM: JOBID $JOBID"
-elif [[ $SUBC == *condor* ]]; then
-    "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT" "$h_vmem" "$tmpdir_size"
-    echo
-    echo "-------------------------------------------------------------------------------"
-    echo "Job submission using HTCondor - run the following script to submit jobs at once:"
-    echo "$EVNDISPSCRIPTS/helper_scripts/submit_scripts_to_htcondor.sh ${LOGDIR} submit"
-    echo "-------------------------------------------------------------------------------"
-    echo
-elif [[ $SUBC == *sbatch* ]]; then
-        # shellcheck disable=SC2086
-        $SUBC "$FSCRIPT"
-elif [[ $SUBC == *parallel* ]]; then
-    echo "$FSCRIPT &> $FSCRIPT.log" >> "$LOGDIR/runscripts.dat"
-fi
+    submit_job "$FSCRIPT" "$FSCRIPT &> $FSCRIPT.log" "$LOGDIR/runscripts.dat"
+    if [[ $SUBC == *qsub* ]]; then
+        echo "RUN $RUNNUM: JOBID $JOBID"
+    fi

--- a/scripts/SPANALYSIS.lowgainped.sh
+++ b/scripts/SPANALYSIS.lowgainped.sh
@@ -4,6 +4,8 @@
 # qsub parameters
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=11:59:00; h_vmem=2000M; tmpdir_size=25G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 if [ ! -n "$1" ] || [ ! -n "$2" ] || [ "$1" = "-h" ]; then
 # begin help message
@@ -107,37 +109,20 @@ do
         exit
     fi
     echo "$SUBC"
-    if [[ $SUBC == *qsub* ]]; then
-        # shellcheck disable=SC2086
-        JOBID=$($SUBC "$FSCRIPT".sh)
-        # account for -terse changing the job number format
-        if [[ $SUBC != *-terse* ]] ; then
-            echo "without -terse!"      # need to match VVVVVVVV  8539483  and 3843483.1-4:2
-            JOBID=$( echo "$JOBID" | grep -oP "Your job [0-9.-:]+" | awk '{ print $3 }' )
+        submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$LOGDIR/runscripts.dat"
+        if [[ $SUBC == *qsub* ]]; then
+            echo "RUN $AFILE JOBID $JOBID"
+            echo "RUN $AFILE SCRIPT $FSCRIPT.sh"
+            if [[ $SUBC != */dev/null* ]] ; then
+                echo "RUN $AFILE OLOG $FSCRIPT.sh.o$JOBID"
+                echo "RUN $AFILE ELOG $FSCRIPT.sh.e$JOBID"
+            fi
+        elif [[ $SUBC == *parallel* ]]; then
+            echo "RUN $AFILE OLOG $FSCRIPT.log"
         fi
-
-        echo "RUN $AFILE JOBID $JOBID"
-        echo "RUN $AFILE SCRIPT $FSCRIPT.sh"
-        if [[ $SUBC != */dev/null* ]] ; then
-            echo "RUN $AFILE OLOG $FSCRIPT.sh.o$JOBID"
-            echo "RUN $AFILE ELOG $FSCRIPT.sh.e$JOBID"
-        fi
-    elif [[ $SUBC == *condor* ]]; then
-        "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT.sh" "$h_vmem" "$tmpdir_size"
-        condor_submit "$FSCRIPT".sh.condor
-    elif [[ $SUBC == *sbatch* ]]; then
-        # shellcheck disable=SC2086
-        $SUBC "$FSCRIPT".sh
-    elif [[ $SUBC == *parallel* ]]; then
-        echo "$FSCRIPT.sh &> $FSCRIPT.log" >> "$LOGDIR"/runscripts.dat
-        echo "RUN $AFILE OLOG $FSCRIPT.log"
-    fi
 done
 
 # Execute all FSCRIPTs locally in parallel
-if [[ $SUBC == *parallel* ]]; then
-    # shellcheck disable=SC2086
-    cat "$LOGDIR"/runscripts.dat | $SUBC
-fi
+run_parallel_jobs "$LOGDIR/runscripts.dat"
 
 exit

--- a/scripts/SPANALYSIS.make_DST.sh
+++ b/scripts/SPANALYSIS.make_DST.sh
@@ -4,6 +4,8 @@
 # qsub parameters
 # shellcheck disable=SC2034  # SGE resource directives, read by job scheduler
 h_cpu=11:29:00; h_vmem=4000M; tmpdir_size=40G
+# shellcheck source=scripts/helper_scripts/UTILITY.submitJob.sh
+source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
 
 if [[ $# -lt 2 ]]; then
 # begin help message
@@ -101,27 +103,13 @@ for RUN in $RUNNUMS; do
     # run locally or on cluster
     SUBC=$("$(dirname "$0")/helper_scripts/UTILITY.readSubmissionCommand.sh")
     SUBC=$(eval "echo \"$SUBC\"")
-    if [[ $SUBC == *qsub* ]]; then
-        # shellcheck disable=SC2086
-        JOBID=$($SUBC "$FSCRIPT".sh)
-		echo "RUN $RUN: JOBID $JOBID"
-    elif [[ $SUBC == *condor* ]]; then
-        "$(dirname "$0")/helper_scripts/UTILITY.condorSubmission.sh" "$FSCRIPT.sh" "$h_vmem" "$tmpdir_size"
-        condor_submit "$FSCRIPT".sh.condor
-    elif [[ $SUBC == *sbatch* ]]; then
-            # shellcheck disable=SC2086
-            $SUBC "$FSCRIPT".sh
-    elif [[ $SUBC == *parallel* ]]; then
-        echo "$FSCRIPT.sh &> $FSCRIPT.log" >> "$LOGDIR"/runscripts.dat
-    elif [[ $SUBC == *simple* ]]; then
-        "$FSCRIPT".sh |& tee "$FSCRIPT".log
-    fi
+        submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$LOGDIR/runscripts.dat"
+        if [[ $SUBC == *qsub* ]]; then
+            echo "RUN $RUN: JOBID $JOBID"
+        fi
 done
 
 # Execute all FSCRIPTs locally in parallel
-if [[ $SUBC == *parallel* ]]; then
-    # shellcheck disable=SC2086
-    cat "$LOGDIR"/runscripts.dat | $SUBC
-fi
+run_parallel_jobs "$LOGDIR/runscripts.dat"
 
 exit

--- a/scripts/helper_scripts/UTILITY.submitJob.sh
+++ b/scripts/helper_scripts/UTILITY.submitJob.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Shared job submission utility.
+# Source this file to use submit_job() and run_parallel_jobs().
+#
+# submit_job <fscript> [parallel_line [parallel_file]]
+#   fscript:       full path to the script to submit
+#   parallel_line: command to write in parallel mode (default: "$fscript")
+#   parallel_file: file to collect parallel jobs in (default: "$LOGDIR/runscripts.dat")
+# Sets: JOBID (qsub mode only)
+# Requires env: SUBC, LOGDIR, h_vmem, tmpdir_size, EVNDISPSCRIPTS
+submit_job() {
+    local fscript="$1"
+    local parallel_line="${2:-$fscript}"
+    local parallel_file="${3:-$LOGDIR/runscripts.dat}"
+    local subc_dir
+    subc_dir="$(dirname "${BASH_SOURCE[0]}")"
+    # Word-split $SUBC into array for safe expansion (SUBC is a pre-expanded command string)
+    read -ra subc_arr <<< "$SUBC"
+
+    if [[ "$SUBC" == *qsub* ]]; then
+        JOBID=$("${subc_arr[@]}" "$fscript")
+        # account for -terse changing the job number format
+        if [[ "$SUBC" != *-terse* ]]; then
+            echo "without -terse!"
+            JOBID=$(echo "$JOBID" | grep -oP "Your job [0-9.-:]+" | awk '{ print $3 }')
+        fi
+    elif [[ "$SUBC" == *condor_submit* ]]; then
+        "$subc_dir/UTILITY.condorSubmission.sh" "$fscript" "${h_vmem-}" "${tmpdir_size-}"
+        condor_submit "$fscript.condor"
+    elif [[ "$SUBC" == *condor* ]]; then
+        "$subc_dir/UTILITY.condorSubmission.sh" "$fscript" "${h_vmem-}" "${tmpdir_size-}"
+        echo "-------------------------------------------------------------------------------"
+        echo "Job submission using HTCondor - run the following script to submit jobs:"
+        echo "$EVNDISPSCRIPTS/helper_scripts/submit_scripts_to_htcondor.sh ${LOGDIR} submit"
+        echo "-------------------------------------------------------------------------------"
+    elif [[ "$SUBC" == *sbatch* ]]; then
+        "${subc_arr[@]}" "$fscript"
+    elif [[ "$SUBC" == *parallel* ]]; then
+        echo "$parallel_line" >> "$parallel_file"
+    elif [[ "$SUBC" == *simple* ]]; then
+        "$fscript" |& tee "$fscript.log"
+    elif [[ "$SUBC" == *test* ]]; then
+        echo "TESTING SCRIPT $fscript"
+    fi
+}
+
+# run_parallel_jobs [parallel_file]
+#   parallel_file: file containing parallel jobs (default: "$LOGDIR/runscripts.dat")
+# Requires env: SUBC
+run_parallel_jobs() {
+    [[ "$SUBC" != *parallel* ]] && return
+    local parallel_file="${1:-$LOGDIR/runscripts.dat}"
+    read -ra subc_arr <<< "$SUBC"
+    sort -u "$parallel_file" | "${subc_arr[@]}"
+}

--- a/scripts/helper_scripts/UTILITY.submitJob.sh
+++ b/scripts/helper_scripts/UTILITY.submitJob.sh
@@ -31,14 +31,15 @@ submit_job() {
         "$subc_dir/UTILITY.condorSubmission.sh" "$fscript" "${h_vmem-}" "${tmpdir_size-}"
         echo "-------------------------------------------------------------------------------"
         echo "Job submission using HTCondor - run the following script to submit jobs:"
-        echo "$EVNDISPSCRIPTS/helper_scripts/submit_scripts_to_htcondor.sh ${LOGDIR} submit"
+        echo "$EVNDISPSCRIPTS/helper_scripts/submit_scripts_to_htcondor.sh ${LOGDIR} ${CONDOR_SUBMIT_ARGS:-submit}"
         echo "-------------------------------------------------------------------------------"
     elif [[ "$SUBC" == *sbatch* ]]; then
         "${subc_arr[@]}" "$fscript"
     elif [[ "$SUBC" == *parallel* ]]; then
         echo "$parallel_line" >> "$parallel_file"
     elif [[ "$SUBC" == *simple* ]]; then
-        "$fscript" |& tee "$fscript.log"
+        local logfile="${fscript%.sh}.log"
+        "$fscript" |& tee "$logfile"
     elif [[ "$SUBC" == *test* ]]; then
         echo "TESTING SCRIPT $fscript"
     fi


### PR DESCRIPTION
## Summary

Refactors the duplicated job submission logic found in all analysis scripts into a single shared utility, eliminating ~320 lines of duplicated code and all remaining SC2086 shellcheck warnings.

## Problem

Every one of the 22 analysis/IRF/SPANALYSIS scripts contained an identical (or nearly identical) 15–20 line `if/elif` block for job submission:

```bash
if [[ $SUBC == *qsub* ]]; then
    # shellcheck disable=SC2086
    JOBID=$($SUBC "$FSCRIPT".sh)
    ...
elif [[ $SUBC == *condor* ]]; then
    ...
elif [[ $SUBC == *sbatch* ]]; then
    # shellcheck disable=SC2086
    $SUBC "$FSCRIPT".sh
elif [[ $SUBC == *parallel* ]]; then
    ...
elif [[ "$SUBC" == *simple* ]]; then
    ...
fi
```

This caused:
- Massive code duplication (same block repeated 22 times)
- All remaining `# shellcheck disable=SC2086` suppressions (for `$SUBC`)
- Inconsistent condor/condor_submit behaviour across scripts

## Solution

### New file: `scripts/helper_scripts/UTILITY.submitJob.sh`

Provides two functions sourced by all scripts:

- **`submit_job <fscript> [parallel_line [parallel_file]]`** — handles all scheduler types (qsub, condor, condor_submit, sbatch, parallel, simple, test)
- **`run_parallel_jobs [parallel_file]`** — runs collected jobs with GNU parallel after the main loop

Inside the function, `$SUBC` is split into an array with `read -ra subc_arr <<< "$SUBC"`, which is equivalent to the previously unquoted usage but shellcheck-clean.

### Each of the 22 scripts now does

```bash
source "$(dirname "$0")/helper_scripts/UTILITY.submitJob.sh"
# ...
submit_job "$FSCRIPT.sh" "$FSCRIPT.sh &> $FSCRIPT.log" "$LOGDIR/runscripts.dat"
echo "RUN $FILE JOBID $JOBID"   # per-script echo kept in place
```

## Changes

| | Before | After |
|---|---|---|
| Lines of code | +469 | +151 |
| SC2086 disables | 52 | 0 |
| Shellcheck violations | 0 | 0 |

**Scripts updated** (22): `ANALYSIS.anasum`, `ANALYSIS.anasum_combine`, `ANALYSIS.anasum_parallel_from_runlist`, `ANALYSIS.dispXGB`, `ANALYSIS.evndisp`, `ANALYSIS.evndisp_laser`, `ANALYSIS.evndisp_muon`, `ANALYSIS.mscw_energy`, `ANALYSIS.v2dl3`, `IRF.combine_effective_area_parts`, `IRF.combine_lookup_table_parts`, `IRF.compress_evndisp_MC`, `IRF.generate_effective_area_parts`, `IRF.generate_lookup_table_parts`, `IRF.generate_radial_acceptance`, `IRF.mscw_energy_MC`, `IRF.optimizeTMVAforGammaHadronSeparation`, `IRF.trainTMVAforAngularReconstruction`, `IRF.trainTMVAforGammaHadronSeparation`, `IRF.trainXGBforAngularReconstructionBinned`, `SPANALYSIS.lowgainped`, `SPANALYSIS.make_DST`

## Bug fix (bonus)

The `condor` / `condor_submit` distinction in `submissionCommands.dat` was not consistently respected. Some scripts always called `condor_submit` regardless of which condor variant the user had selected. The shared function now correctly checks `*condor_submit*` before `*condor*`, so automatic submission only happens when the user explicitly selects `condor_submit` mode.

## Testing

- `shellcheck --severity=info scripts/*.sh scripts/helper_scripts/*.sh` → 0 violations ✅
- No `# shellcheck disable=SC2086` lines remain anywhere ✅