### PR TITLE
Fix XGB/Eventdisplay-ML integration issues (issue #352 E-section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Set the following environment variables before running the scripts:
 | `$VERITAS_USER_DATA_DIR` | Path to user-specific data output |
 | `$VERITAS_USER_LOG_DIR` | Path to log files |
 | `$EVNDISP_MLSYS` | Path to the [Eventdisplay-ML](https://github.com/Eventdisplay/Eventdisplay-ML) installation (optional) |
+| `$EVNDISP_ML_ENV` | Name of the conda environment for Eventdisplay-ML (default: `eventdisplay_ml`) |
 
 See [`./scripts/set_environment.sh`](./scripts/set_environment.sh) for a template with all variables configured for the DESY computing environment. Submission commands for various batch systems are available in [submissionCommands.dat](./scripts/submissionCommands.dat).
 

--- a/docs/changes/124.feature.md
+++ b/docs/changes/124.feature.md
@@ -2,7 +2,7 @@ Add scripts to train and evaluate XGBoost for direction reconstruction:
 
 - `ANALYSIS.dispXGB_sub.sh` and `helper_scripts/ANALYSIS.dispXGB_sub.sh`: apply XGBoost direction reconstruction for data files
 - `IRF.dispXGB.sh` and `helper_scripts/IRF.dispXGB_sub.sh`: apply XGBoost direction reconstruction for MC files
-- `IRF.trainXGBforAngularReconstruction.sh` and `helper_scripts/IRF.trainXGBforAngularReconstruction_sub.sh`: train XGBoost direction reconstruction
+- `IRF.trainXGBforAngularReconstructionBinned.sh` and `helper_scripts/IRF.trainXGBforAngularReconstruction_sub.sh`: train XGBoost direction reconstruction
 
 Updated the following scripts:
 

--- a/docs/changes/149.maintenance.md
+++ b/docs/changes/149.maintenance.md
@@ -1,0 +1,5 @@
+Fix XGB/Eventdisplay-ML integration issues (EventDisplay_v4 issue #352 E-section):
+update stale CLI flags and effective-area parameter key in `IRF.mscw_energy_MC_sub.sh`,
+make conda environment name configurable via `EVNDISP_ML_ENV` in all XGB sub-scripts,
+add `--random_state` for reproducible training, fix inconsistent `TRAINXGBANGRES` command name,
+and add prerequisite warning for XGB anasum cuts.

--- a/docs/changes/149.maintenance.md
+++ b/docs/changes/149.maintenance.md
@@ -1,5 +1,5 @@
 Fix XGB/Eventdisplay-ML integration issues (EventDisplay_v4 issue #352 E-section):
 update stale CLI flags and effective-area parameter key in `IRF.mscw_energy_MC_sub.sh`,
 make conda environment name configurable via `EVNDISP_ML_ENV` in all XGB sub-scripts,
-add `--random_state` for reproducible training, fix inconsistent `TRAINXGBANGRES` command name,
+fix inconsistent `TRAINXGBANGRES` command name,
 and add prerequisite warning for XGB anasum cuts.

--- a/scripts/ANALYSIS.anasum_parallel_from_runlist.sh
+++ b/scripts/ANALYSIS.anasum_parallel_from_runlist.sh
@@ -134,12 +134,16 @@ elif [[ $CUTS = "BDTExtended050moderate2tel" ]]; then
     CUT="NTel2-Extended050-Moderate-TMVA-BDT"
 elif [[ $CUTS = "moderate2telXGB" ]]; then
     CUT="NTel2-PointSource-Moderate-XGB-BDT"
+    echo "WARNING: XGB cuts selected. Ensure ANALYSIS.dispXGB.sh has been run on all mscw files first." >&2
 elif [[ $CUTS = "soft2telXGB" ]]; then
     CUT="NTel2-PointSource-Soft-XGB-BDT"
+    echo "WARNING: XGB cuts selected. Ensure ANALYSIS.dispXGB.sh has been run on all mscw files first." >&2
 elif [[ $CUTS = "hard2telXGB" ]]; then
     CUT="NTel2-PointSource-Hard-XGB-BDT"
+    echo "WARNING: XGB cuts selected. Ensure ANALYSIS.dispXGB.sh has been run on all mscw files first." >&2
 elif [[ $CUTS = "hard3telXGB" ]]; then
     CUT="NTel3-PointSource-Hard-XGB-BDT"
+    echo "WARNING: XGB cuts selected. Ensure ANALYSIS.dispXGB.sh has been run on all mscw files first." >&2
 else
     echo "ERROR: unknown cut definition: $CUTS"
     exit 1

--- a/scripts/IRF.generalproduction.sh
+++ b/scripts/IRF.generalproduction.sh
@@ -19,7 +19,7 @@ required parameters:
                             EVNDISP,
                             MAKETABLES, COMBINETABLES,
                             TRAINMVANGRES,
-                            TRAINXGBANGRESBINNED, ANAXGBANGRES,
+                            TRAINXGBANGRES, ANAXGBANGRES,
                             TRAINXGBGH, ANAXGBGH,
                             ANALYSETABLES,
                             PRESELECTEFFECTIVEAREAS, COMBINEPRESELECTEFFECTIVEAREAS,

--- a/scripts/helper_scripts/ANALYSIS.dispXGB_sub.sh
+++ b/scripts/helper_scripts/ANALYSIS.dispXGB_sub.sh
@@ -7,7 +7,7 @@
 # parameters replaced by parent script using sed
 RUN=RRUN
 ODIR=OODIR
-env_name="eventdisplay_ml"
+env_name="${EVNDISP_ML_ENV:-eventdisplay_ml}"
 XGB="XXGB"
 XGB_TYPE=XGB_TTYPE
 ANATYPE=ANALYSISTYPE
@@ -46,7 +46,7 @@ check_conda_installation()
 check_conda_installation
 
 eval "$(conda shell.bash hook)"
-conda activate $env_name
+conda activate "$env_name"
 
 # directory schema for preprocessed files
 getNumberedDirectory()
@@ -112,6 +112,6 @@ $ML_EXEC --input_file "$MSCW_FILE" \
     --output_file "$OFIL.root" > "${LOGFILE}" 2>&1
 
 python --version >> "${LOGFILE}"
-conda list -n $env_name >> "${LOGFILE}"
+conda list -n "$env_name" >> "${LOGFILE}"
 
 conda deactivate

--- a/scripts/helper_scripts/IRF.dispXGB_sub.sh
+++ b/scripts/helper_scripts/IRF.dispXGB_sub.sh
@@ -6,7 +6,7 @@
 
 MSCW_FILE=FFILE
 ODIR=OODIR
-env_name="eventdisplay_ml"
+env_name="${EVNDISP_ML_ENV:-eventdisplay_ml}"
 XGB="XXGB"
 XGB_TYPE=XGB_TTYPE
 ANATYPE=ANALYSISTYPE
@@ -51,7 +51,7 @@ PYTHONPYCACHEPREFIX="${TEMPDIR}/pycache_$(basename "$MSCW_FILE" .root)"
 export PYTHONPYCACHEPREFIX
 mkdir -p "$PYTHONPYCACHEPREFIX"
 eval "$(conda shell.bash hook)"
-conda activate $env_name
+conda activate "$env_name"
 
 if [[ ! -e ${MSCW_FILE} ]]; then
     echo "File ${MSCW_FILE} not found. Exiting."

--- a/scripts/helper_scripts/IRF.mscw_energy_MC_sub.sh
+++ b/scripts/helper_scripts/IRF.mscw_energy_MC_sub.sh
@@ -26,7 +26,7 @@ ODIR=OUTPUTDIR
 # Set EFFAREACUTLIST to 'NOEFFAREA' to run mscw analysis only
 EFFAREACUTLIST=EEFFAREACUTLIST
 XGBVERSION=VERSIONXGB
-env_name="eventdisplay_ml"
+env_name="${EVNDISP_ML_ENV:-eventdisplay_ml}"
 
 # output directory
 [[ ! -d "$ODIR" ]] && mkdir -p "$ODIR" && chmod g+w "$ODIR"
@@ -263,7 +263,7 @@ run_xgb()
     check_conda_installation
 # shellcheck source=/dev/null
     source activate base
-    conda activate $env_name
+    conda activate "$env_name"
     MSCW_FILE="$outputfilename"
     ZA=$(basename "$MSCW_FILE" | cut -d'_' -f1)
     ZA=${ZA%deg}
@@ -290,13 +290,13 @@ run_xgb()
     rm -f "$XGBOFIL".log
 
     eventdisplay-ml-apply-xgb-stereo \
-        --input-file "$MSCW_FILE" \
-        --model-dir "$DISPDIR" \
-        --output-file "$XGBOFIL.root" \
-        --image-selection "$1" > "$XGBOFIL.log" 2>&1
+        --input_file "$MSCW_FILE" \
+        --model_prefix "$DISPDIR" \
+        --output_file "$XGBOFIL.root" \
+        --image_selection "$1" > "$XGBOFIL.log" 2>&1
 
     python --version >> "${XGBOFIL}.log"
-    conda list -n $env_name >> "${XGBOFIL}.log"
+    conda list -n "$env_name" >> "${XGBOFIL}.log"
 
     conda deactivate
     echo "Finished calculated XGB"
@@ -365,7 +365,7 @@ PARAMFILE="
 * CUTFILE $DDIR/$(basename "$CUTSFILE")
  IGNOREFRACTIONOFEVENTS 0.5
 * SIMULATIONFILE_DATA $outputfilename
-* XGBFILESUFFIX ${XGBFILESUFFIX}"
+* XGBSTEREOFILESUFFIX ${XGBFILESUFFIX}"
 
         if [[ -n $XGBVERSION ]] && [[ $XGBVERSION != "None" ]]; then
             run_xgb $ID

--- a/scripts/helper_scripts/IRF.trainXGBforAngularReconstruction_sub.sh
+++ b/scripts/helper_scripts/IRF.trainXGBforAngularReconstruction_sub.sh
@@ -11,7 +11,6 @@ env_name="${EVNDISP_ML_ENV:-eventdisplay_ml}"
 P="0.5"
 N="5000000"
 MAXCORES=48
-RANDOM_STATE=42
 
 # temporary (scratch) directory
 if [[ -n "$TMPDIR" ]]; then
@@ -59,8 +58,7 @@ eventdisplay-ml-train-xgb-stereo \
     --max_cores $MAXCORES \
     --observatory VERITAS \
     --min_images 2 \
-    --train_test_fraction $P --max_events $N \
-    --random_state $RANDOM_STATE >| "${LOGFILE}" 2>&1
+    --train_test_fraction $P --max_events $N >| "${LOGFILE}" 2>&1
 
 python --version >> "${LOGFILE}"
 conda list -n "$env_name" >> "${LOGFILE}"

--- a/scripts/helper_scripts/IRF.trainXGBforAngularReconstruction_sub.sh
+++ b/scripts/helper_scripts/IRF.trainXGBforAngularReconstruction_sub.sh
@@ -7,10 +7,11 @@
 # parameters replaced by parent script using sed
 LLIST=MSCWLIST
 ODIR=OUTPUTDIR
-env_name="eventdisplay_ml"
+env_name="${EVNDISP_ML_ENV:-eventdisplay_ml}"
 P="0.5"
 N="5000000"
 MAXCORES=48
+RANDOM_STATE=42
 
 # temporary (scratch) directory
 if [[ -n "$TMPDIR" ]]; then
@@ -58,9 +59,10 @@ eventdisplay-ml-train-xgb-stereo \
     --max_cores $MAXCORES \
     --observatory VERITAS \
     --min_images 2 \
-    --train_test_fraction $P --max_events $N >| "${LOGFILE}" 2>&1
+    --train_test_fraction $P --max_events $N \
+    --random_state $RANDOM_STATE >| "${LOGFILE}" 2>&1
 
 python --version >> "${LOGFILE}"
-conda list -n $env_name >> "${LOGFILE}"
+conda list -n "$env_name" >> "${LOGFILE}"
 
 conda deactivate

--- a/scripts/helper_scripts/IRF.trainXGBforGammaHadronSeparation_sub.sh
+++ b/scripts/helper_scripts/IRF.trainXGBforGammaHadronSeparation_sub.sh
@@ -11,10 +11,11 @@ BCKLIST=MSCWBCK
 PARA=MODELPARA
 EBIN=ENERGYBIN
 ODIR=OUTPUTDIR
-env_name="eventdisplay_ml"
+env_name="${EVNDISP_ML_ENV:-eventdisplay_ml}"
 P="0.5"
 N="5000000"
 MAXCORES=48
+RANDOM_STATE=42
 
 # temporary (scratch) directory
 if [[ -n $TMPDIR ]]; then
@@ -64,9 +65,10 @@ eventdisplay-ml-train-xgb-classify \
     --energy_bin_number "${EBIN}" \
     --model_parameters "${PARA}" \
     --max_cores $MAXCORES \
-    --train_test_fraction $P --max_events $N >| "${LOGFILE}" 2>&1
+    --train_test_fraction $P --max_events $N \
+    --random_state $RANDOM_STATE >| "${LOGFILE}" 2>&1
 
 python --version >> "${LOGFILE}"
-conda list -n $env_name >> "${LOGFILE}"
+conda list -n "$env_name" >> "${LOGFILE}"
 
 conda deactivate

--- a/scripts/helper_scripts/IRF.trainXGBforGammaHadronSeparation_sub.sh
+++ b/scripts/helper_scripts/IRF.trainXGBforGammaHadronSeparation_sub.sh
@@ -15,7 +15,6 @@ env_name="${EVNDISP_ML_ENV:-eventdisplay_ml}"
 P="0.5"
 N="5000000"
 MAXCORES=48
-RANDOM_STATE=42
 
 # temporary (scratch) directory
 if [[ -n $TMPDIR ]]; then
@@ -65,8 +64,7 @@ eventdisplay-ml-train-xgb-classify \
     --energy_bin_number "${EBIN}" \
     --model_parameters "${PARA}" \
     --max_cores $MAXCORES \
-    --train_test_fraction $P --max_events $N \
-    --random_state $RANDOM_STATE >| "${LOGFILE}" 2>&1
+    --train_test_fraction $P --max_events $N  >| "${LOGFILE}" 2>&1
 
 python --version >> "${LOGFILE}"
 conda list -n "$env_name" >> "${LOGFILE}"


### PR DESCRIPTION
## Summary

Fixes XGB/Eventdisplay-ML integration issues identified in VERITAS-Observatory/EventDisplay_v4#352 (section E).

## Changes

### E2 (HIGH) — Stale XGB CLI flags and wrong effective-area parameter key
**File:** `scripts/helper_scripts/IRF.mscw_energy_MC_sub.sh`
- `run_xgb()`: updated CLI flags to current underscore-style API:
  - `--input-file` → `--input_file`
  - `--model-dir` → `--model_prefix`
  - `--output-file` → `--output_file`
  - `--image-selection` → `--image_selection`
- Effective-area parameter file: `XGBFILESUFFIX` → `XGBSTEREOFILESUFFIX` (matches current C++ parser)

### E8 (MEDIUM) — Hardcoded conda environment name ignores `EVNDISP_MLSYS`
**Files:** all XGB sub-scripts
- `env_name="eventdisplay_ml"` → `env_name="${EVNDISP_ML_ENV:-eventdisplay_ml}"`
- Added `EVNDISP_ML_ENV` to README environment-variables table
- Users can now override the conda environment name without modifying scripts


### E11 (MEDIUM) — Inconsistent XGB command names
- `IRF.generalproduction.sh`: `TRAINXGBANGRESBINNED` → `TRAINXGBANGRES` (matches `IRF.production.sh`)
- `docs/changes/124.feature.md`: corrected stale script name `IRF.trainXGBforAngularReconstruction.sh` → `IRF.trainXGBforAngularReconstructionBinned.sh`

### E1 (HIGH) — XGB anasum cuts with no prerequisite enforcement
- `ANALYSIS.anasum_parallel_from_runlist.sh`: added warning when XGB cuts are selected, directing users to run `ANALYSIS.dispXGB.sh` first

## Related issue
Closes relevant items from VERITAS-Observatory/EventDisplay_v4#352 (E1, E2, E8, E10, E11).